### PR TITLE
Remove discreeter and footer

### DIFF
--- a/src/bika/cement/reports/OzingaSingle.pt
+++ b/src/bika/cement/reports/OzingaSingle.pt
@@ -555,62 +555,6 @@
     </div>
   </tal:render>
 
-  <h1 i18n:translate="">End of Report</h1>
-  <br />
-
-  <!-- DISCREETER -->
-  <tal:render condition="python:True"
-              define="laboratory python:view.laboratory;
-                      contact model/Contact">
-    <div class="row section-discreeter no-gutters">
-      <div class="w-100 text-muted font-weight-light small">
-        <div class="discreeter-outofrange">
-          <span class="outofrange text-danger">
-              <img tal:attributes="src python:report_images['outofrange_symbol_url']"/>
-          </span>
-          <span i18n:translate="">Result out of specified range.</span>
-        </div>
-        <div class="discreeter-not-invoiced"
-             tal:condition="model/InvoiceExclude"
-             i18n:translate="">
-          Not invoiced
-        </div>
-        <div class="discreeter-methods"
-             tal:condition="laboratory/LaboratoryAccredited">
-          <span class="accredited-symbol text-success">
-            <img tal:attributes="src python:report_images['accredited_symbol_url']"/>
-          </span>
-          <span class="" i18n:translate="">
-            Methods included in the
-            <tal:block replace="laboratory/AccreditationBody" i18n:name="accreditation_body"/>
-            schedule of Accreditation for this Laboratory.
-          </span>
-        </div>
-        <div class="discreeter-disclaimer"
-             i18n:translate="">
-            Analysis remarks are not accredited.
-        </div>
-        <div class="discreeter-disclaimer"
-             i18n:translate="">
-          Analysis results relate only to the samples tested.
-        </div>
-        <div class="discreeter-disclaimer"
-             i18n:translate="">
-          All information provided by <tal:block replace="laboratory/title"/> except for the Client Sample ID provided by <tal:block replace="client/Name"/>.
-        </div>
-        <div tal:define="confidence_level laboratory/Confidence"
-             tal:condition="confidence_level" i18n:translate="">
-          Test results are at a <tal:block replace="confidence_level" i18n:name="lab_confidence"/>% confidence level
-        </div>
-        <div class="discreeter-copyright"
-             i18n:translate="">
-          This document shall not be reproduced except in full, without the written approval of
-          <tal:block replace="laboratory/title" i18n:name="name_lab"/>
-        </div>
-      </div>
-    </div>
-  </tal:render>
-
   <!-- CUSTOM FOOTER -->
   <tal:render condition="python:footer">
     <div class="row section-footer no-gutters">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-962

## Current behavior before PR

End of report and discreeter information are visible.

## Desired behavior after PR is merged

End of report line and discreeter have been removed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
