### PR TITLE
Remove Verifier column

### DIFF
--- a/src/bika/cement/reports/OzingaSingle.pt
+++ b/src/bika/cement/reports/OzingaSingle.pt
@@ -296,13 +296,11 @@
             <table class="table table-sm table-condensed">
               <colgroup>
                 <!-- Category -->
-                <col style="width: 15%;">
+                <col style="width: 25%;">
                 <!-- Analyst -->
-                <col style="width: 13%;">
-                <!-- Verifier -->
-                <col style="width: 13%;">
+                <col style="width: 14%;">
                 <!-- Date -->
-                <col style="width: 13%;">
+                <col style="width: 15%;">
                 <!-- Result -->
                 <col style="width: 13%">
                 <!-- Unit -->
@@ -319,9 +317,6 @@
                   </th>
                   <th class="text-left method">
                     <span i18n:translate="">Analyst</span>
-                  </th>
-                  <th class="text-left method">
-                    <span i18n:translate="">Verifier</span>
                   </th>
                   <th class="text-left capture-date">
                     <span i18n:translate="">Date</span>
@@ -361,14 +356,6 @@
                       </span>
                       <span tal:condition="not: analysis/Method">
                         <span class="font-normal">-</span> 
-                      </span>
-                    </td>
-                    <td class="text-left" tal:define="verifier python:view.get_verifier_by_analysis(analysis)">
-                      <span tal:condition="verifier">
-                        <span class="font-normal" tal:content="verifier/verifier"></span>
-                      </span>
-                      <span tal:condition="not: verifier">
-                        <span class="font-normal">-</span>
                       </span>
                     </td>
                     <td class="text-left">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-972

## Current behavior before PR

The verifier column is in the results table and taking up valuable space.

## Desired behavior after PR is merged

The verifier column has been removed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
