### PR TITLE
Notes normalization

### DIFF
--- a/src/bika/cement/reports/OzingaSingle.pt
+++ b/src/bika/cement/reports/OzingaSingle.pt
@@ -74,7 +74,6 @@
     .report .notes-header {
         font-size: 110%;
         font-weight: bold;
-        text-decoration: underline;
     }
     .report .sample-info {
         font-size: 110%;
@@ -405,8 +404,9 @@
          tal:define="ris python:model.get_resultsinterpretation();
                      has_ri python:any(map(lambda r: r.get('richtext'), ris));">
       <div class="" tal:condition="has_ri">
+        <h2 class="notes-header">Notes</h2>
         <tal:ri repeat="ri ris">
-          <h2 tal:condition="ri/richtext|nothing" class="notes-header" tal:content="string:${ri/title} Notes:" >Notes:</h2>
+          <h2 tal:condition="ri/richtext|nothing" class="notes-header" tal:content="string:${ri/title}:" ></h2>
           <div tal:content="structure ri/richtext|nothing"></div>
         </tal:ri>
       </div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-973

## Current behavior before PR

"Notes" appears after each result interpretation category.

Notes and Applicable Test Methods are underlined.

## Desired behavior after PR is merged

One "Notes" header without any underlining on Notes and Applicable Test Methods.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
