### PR TITLE
Removed separator lines in header table

### DIFF
--- a/src/bika/cement/reports/OzingaSingle.pt
+++ b/src/bika/cement/reports/OzingaSingle.pt
@@ -100,6 +100,13 @@
      .report .section-footer #footer-contacts {
        margin-top: 3mm;
      }
+      .no-borders {
+        border-collapse: collapse;
+     }
+      .no-borders td, .no-borders th {
+        border: none !important;
+     }
+
 
      <tal:block condition="python:content_width and content_height">
      <tal:block condition="python:all([content_width, content_height])"
@@ -150,7 +157,7 @@
                       publication_specification model/PublicationSpecification;
                       spec python:publication_specification or specification;">
 
-    <div class="row section-info no-gutters">
+    <div class="row section-info no-gutters no-borders">
       <div class="w-100">
         <!-- Client Info -->
         <table class="table table-sm table-condensed">

--- a/src/bika/cement/reports/OzingaSingle.pt
+++ b/src/bika/cement/reports/OzingaSingle.pt
@@ -104,7 +104,6 @@
         border: none !important;
      }
 
-
      <tal:block condition="python:content_width and content_height">
      <tal:block condition="python:all([content_width, content_height])"
                    define="cw python:float(content_width);

--- a/src/bika/cement/reports/OzingaSingle.pt
+++ b/src/bika/cement/reports/OzingaSingle.pt
@@ -100,9 +100,6 @@
      .report .section-footer #footer-contacts {
        margin-top: 3mm;
      }
-      .no-borders {
-        border-collapse: collapse;
-     }
       .no-borders td, .no-borders th {
         border: none !important;
      }


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-971

## Current behavior before PR

Has lines separating content header table.

## Desired behavior after PR is merged

Has no lines separating content header table.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
