### PR TITLE
Lims 974 lose lab in spec

### DIFF
--- a/src/bika/cement/reports/OzingaSingle.pt
+++ b/src/bika/cement/reports/OzingaSingle.pt
@@ -222,7 +222,7 @@
                 <tr>
                   <td colspan="2" class="field">Specification</td>
                   <td colspan="2" class="sample-info">
-                      <div tal:content="spec/contextual_title|nothing"/>
+                      <div tal:content="spec/title|nothing"/>
                   </td>
                   <td colspan="2" class="field" i18n:translate="">Published by</td>
                   <td colspan="2" class="label">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-974

## Current behavior before PR

The (Lab) i.e contextual title of the specification was showing on the template.

## Desired behavior after PR is merged

The contextual title title has been removed. i.e instead of Crystal (Lab) we now have only Crystal.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
