### PR TITLE
Move publisher email down one row

### DIFF
--- a/src/bika/cement/reports/OzingaSingle.pt
+++ b/src/bika/cement/reports/OzingaSingle.pt
@@ -242,8 +242,8 @@
           <td colspan="2" class="field">
             <tal:email tal:condition="reporter/email|nothing"
                        tal:define="email reporter/email|nothing">
-              (<a tal:content="email"
-                  tal:attributes="href string:mailto:${email}"></a>)
+              <a tal:content="email"
+                  tal:attributes="href string:mailto:${email}"></a>
             </tal:email>
           </td>
         </tr>

--- a/src/bika/cement/reports/OzingaSingle.pt
+++ b/src/bika/cement/reports/OzingaSingle.pt
@@ -227,13 +227,8 @@
               <div tal:content="model/getId"/>
           </td>
           <td colspan="2" class="field" i18n:translate="">Published by</td>
-          <td colspan="2" class="label">
+          <td colspan="2" class="field">
             <span tal:content="reporter/fullname|reporter/username"/>
-            <tal:email tal:condition="reporter/email|nothing"
-                       tal:define="email reporter/email|nothing">
-              (<a tal:content="email"
-                  tal:attributes="href string:mailto:${email}"></a>)
-            </tal:email>
           </td>
         </tr>
         <tr>
@@ -243,7 +238,14 @@
                 <div tal:content="batch/getId"/>
               </div>
           </td>
-          <td colspan="4"></td>
+          <td colspan="2"></td>
+          <td colspan="2" class="field">
+            <tal:email tal:condition="reporter/email|nothing"
+                       tal:define="email reporter/email|nothing">
+              (<a tal:content="email"
+                  tal:attributes="href string:mailto:${email}"></a>)
+            </tal:email>
+          </td>
         </tr>
       </table>
       <div class="clearfix"></div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-977

## Current behavior before PR

Publisher email address goes off the page.

## Desired behavior after PR is merged

Publisher email displays below publisher name.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
