### PR TITLE
Added description to material types control panel view

### DIFF
--- a/src/bika/cement/browser/controlpanel/materialtypefolder.py
+++ b/src/bika/cement/browser/controlpanel/materialtypefolder.py
@@ -58,6 +58,9 @@ class MaterialTypeFolderView(ListingView):
             ("title", {
                 "title": _("Title"),
                 "index": "sortable_title"}),
+            ("description", {
+                "title": _("Description"),
+                "index": "description"}),
         ))
 
         self.review_states = [
@@ -91,5 +94,6 @@ class MaterialTypeFolderView(ListingView):
         obj = api.get_object(obj)
 
         item["replace"]["title"] = get_link_for(obj)
+        item["description"] = api.get_description(obj)
 
         return item


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1060

## Current behavior before PR

No description in control panel view.

## Desired behavior after PR is merged

A description has been added to the control panel view.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
