### PR TITLE
Added Material Class to LIMS setup and added view page

### DIFF
--- a/src/bika/cement/browser/controlpanel/configure.zcml
+++ b/src/bika/cement/browser/controlpanel/configure.zcml
@@ -13,4 +13,12 @@
       permission="senaite.core.permissions.ManageBika"
       layer="bika.cement.interfaces.IBikaCementLayer"/>
 
+  <!-- Material Class Folder -->
+  <browser:page
+      for="bika.cement.content.materialclassfolder.IMaterialClassFolder"
+      name="view"
+      class=".materialclassfolder.MaterialClassFolderView"
+      permission="senaite.core.permissions.ManageBika"
+      layer="bika.cement.interfaces.IBikaCementLayer"/>
+
 </configure>

--- a/src/bika/cement/browser/controlpanel/materialclassfolder.py
+++ b/src/bika/cement/browser/controlpanel/materialclassfolder.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2023 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+import collections
+
+from bika.cement.config import _
+from bika.lims import api
+from bika.lims.utils import get_link_for
+from senaite.app.listing import ListingView
+from senaite.core.catalog import SETUP_CATALOG
+
+
+class MaterialClassFolderView(ListingView):
+    """Displays all available sample containers in a table
+    """
+
+    def __init__(self, context, request):
+        super(MaterialClassFolderView, self).__init__(context, request)
+        self.catalog = SETUP_CATALOG
+
+        self.contentFilter = {
+            "portal_type": "MaterialClass",
+            "sort_on": "sortable_title",
+        }
+         
+        self.context_actions = {
+            _("Add"): {
+                "url": "++add++MaterialClass",
+                "icon": "++resource++bika.lims.images/add.png",
+            }}
+
+        t = self.context.translate
+        self.title = t(_("Material Classes"))
+        self.description = t(_(""))
+
+        self.show_select_column = True
+        self.pagesize = 25
+
+        self.columns = collections.OrderedDict((
+            ("title", {
+                "title": _("Title"),
+                "index": "sortable_title"}),
+            ("description", {
+                "title": _("Description"),
+                "index": "description"}),
+        ))
+
+        self.review_states = [
+            {
+                "id": "default",
+                "title": _("Active"),
+                "contentFilter": {"is_active": True},
+                "columns": self.columns.keys(),
+            }, {
+                "id": "inactive",
+                "title": _("Inactive"),
+                "contentFilter": {'is_active': False},
+                "columns": self.columns.keys(),
+            }, {
+                "id": "all",
+                "title": _("All"),
+                "contentFilter": {},
+                "columns": self.columns.keys(),
+            },
+        ]
+
+    def folderitem(self, obj, item, index):
+        """Service triggered each time an item is iterated in folderitems.
+        The use of this service prevents the extra-loops in child objects.
+
+        :obj: the instance of the class to be foldered
+        :item: dict containing the properties of the object to be used by
+            the template
+        :index: current index of the item
+        """
+        obj = api.get_object(obj)
+
+        item["replace"]["title"] = get_link_for(obj)
+        item["description"] = api.get_description(obj)
+
+        return item

--- a/src/bika/cement/browser/controlpanel/materialclassfolder.py
+++ b/src/bika/cement/browser/controlpanel/materialclassfolder.py
@@ -39,7 +39,7 @@ class MaterialClassFolderView(ListingView):
             "portal_type": "MaterialClass",
             "sort_on": "sortable_title",
         }
-         
+
         self.context_actions = {
             _("Add"): {
                 "url": "++add++MaterialClass",

--- a/src/bika/cement/content/materialclass.py
+++ b/src/bika/cement/content/materialclass.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from AccessControl import ClassSecurityInfo
+from bika.lims.interfaces import IDeactivable
+from plone.dexterity.content import Container
+from plone.supermodel import model
+from senaite.core.catalog import SETUP_CATALOG
+from senaite import api
+from zope.interface import implementer
+
+
+class IMaterialClass(model.Schema):
+    """Marker interface and Dexterity Python Schema for MaterialClass"""
+
+
+@implementer(IMaterialClass, IDeactivable)
+class MaterialClass(Container):
+    """Content-type class for IMaterialClass"""
+
+    _catalogs = [SETUP_CATALOG]
+
+    security = ClassSecurityInfo()
+
+    @security.private
+    def accessor(self, fieldname):
+        """Return the field accessor for the fieldname"""
+        schema = api.get_schema(self)
+        if fieldname not in schema:
+            return None
+        return schema[fieldname].get
+
+    @security.private
+    def mutator(self, fieldname):
+        """Return the field mutator for the fieldname"""
+        schema = api.get_schema(self)
+        if fieldname not in schema:
+            return None
+        result = schema[fieldname].set
+        self.reindexObject()
+        return result

--- a/src/bika/cement/content/materialclassfolder.py
+++ b/src/bika/cement/content/materialclassfolder.py
@@ -31,7 +31,9 @@ class IMaterialClassFolderSchema(model.Schema):
     """
 
 
-@implementer(IMaterialClassFolder, IMaterialClassFolderSchema, IHideActionsMenu)
+@implementer(IMaterialClassFolder,
+             IMaterialClassFolderSchema,
+             IHideActionsMenu)
 class MaterialClassFolder(Container):
     """A folder/container for material classes
     """

--- a/src/bika/cement/content/materialclassfolder.py
+++ b/src/bika/cement/content/materialclassfolder.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2023 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from plone.dexterity.content import Container
+from plone.supermodel import model
+from zope.interface import implementer
+
+from bika.cement.interfaces import IMaterialClassFolder
+from senaite.core.interfaces import IHideActionsMenu
+
+
+class IMaterialClassFolderSchema(model.Schema):
+    """Schema interface
+    """
+
+
+@implementer(IMaterialClassFolder, IMaterialClassFolderSchema, IHideActionsMenu)
+class MaterialClassFolder(Container):
+    """A folder/container for material classes
+    """

--- a/src/bika/cement/interfaces.py
+++ b/src/bika/cement/interfaces.py
@@ -13,3 +13,7 @@ class IBikaCementLayer(IDefaultBrowserLayer):
 class IMaterialTypeFolder(Interface):
     """Marker interface for material type setup folder
     """
+
+class IMaterialClassFolder(Interface):
+    """Marker interface for material class setup folder
+    """

--- a/src/bika/cement/interfaces.py
+++ b/src/bika/cement/interfaces.py
@@ -14,6 +14,7 @@ class IMaterialTypeFolder(Interface):
     """Marker interface for material type setup folder
     """
 
+
 class IMaterialClassFolder(Interface):
     """Marker interface for material class setup folder
     """

--- a/src/bika/cement/profiles/default/types.xml
+++ b/src/bika/cement/profiles/default/types.xml
@@ -5,6 +5,8 @@
   <!-- Material Types -->
   <object name="MaterialType" meta_type="Dexterity FTI" />
   <object name="MaterialTypeFolder" meta_type="Dexterity FTI" />
+  <object name="MaterialClass" meta_type="Dexterity FTI"/>
+  <object name="MaterialClassFolder" meta_type="Dexterity FTI"/>
 
 </object>
 

--- a/src/bika/cement/profiles/default/types/MaterialClass.xml
+++ b/src/bika/cement/profiles/default/types/MaterialClass.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    name="MaterialClass"
+    meta_type="Dexterity FTI"
+    i18n:domain="bika.cement">
+
+  <!-- Basic properties -->
+  <property
+      i18n:translate=""
+      name="title">Material Class</property>
+  <property
+      i18n:translate=""
+      name="description">Material Classes</property>
+
+  <property name="allow_discussion">False</property>
+  <property name="factory">MaterialClass</property>
+  <property name="icon_expr"></property>
+  <property name="link_target"></property>
+
+  <!-- Hierarchy control -->
+  <property name="global_allow">False</property>
+  <property name="filter_content_types">True</property>
+  <!-- Schema, class and security -->
+  <property name="add_permission">cmf.AddPortalContent</property>
+  <property name="model_file"></property>
+  <property name="model_source"></property>
+  <property name="schema">bika.cement.content.materialclass.IMaterialClass</property>
+  <property name="klass">bika.cement.content.materialclass.MaterialClass</property>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors" purge="false">
+    <element value="bika.lims.interfaces.IAutoGenerateID"/>
+    <element value="bika.lims.interfaces.IMultiCatalogBehavior"/>
+    <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
+    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
+  </property>
+
+  <!-- View information -->
+  <property name="add_view_expr">string:${folder_url}/++add++MaterialClass</property>
+  <property name="default_view">view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="immediate_view">view</property>
+  <property name="view_methods">
+    <element value="view"/>
+  </property>
+
+  <!-- Method aliases -->
+  <alias
+      from="(Default)"
+      to="(dynamic view)"
+  />
+  <alias
+      from="edit"
+      to="@@edit"
+  />
+  <alias
+      from="sharing"
+      to="@@sharing"
+  />
+  <alias
+      from="view"
+      to="(selected layout)"
+  />
+
+  <!-- Actions -->
+  <action
+      action_id="view"
+      category="object"
+      condition_expr=""
+      i18n:attributes="title"
+      i18n:domain="plone"
+      title="View"
+      url_expr="string:${object_url}"
+      visible="True">
+    <permission value="View"/>
+  </action>
+  <action
+      action_id="edit"
+      category="object"
+      condition_expr=""
+      i18n:attributes="title"
+      i18n:domain="plone"
+      title="Edit"
+      url_expr="string:${object_url}/edit"
+      visible="True">
+    <permission value="Modify portal content"/>
+  </action>
+
+</object>

--- a/src/bika/cement/profiles/default/types/MaterialClassFolder.xml
+++ b/src/bika/cement/profiles/default/types/MaterialClassFolder.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<object name="MaterialClassFolder" meta_type="Dexterity FTI"
+        i18n:domain="bika.cement"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <!-- Title and Description -->
+  <property name="title"
+            i18n:translate="">Material Classes</property>
+  <property name="description"
+            i18n:translate=""></property>
+
+  <!-- content-type icon -->
+  <property name="icon_expr">senaite_theme/icon/container</property>
+
+  <!-- factory name; usually the same as type name -->
+  <property name="factory">MaterialClassFolder</property>
+
+  <!-- URL TALES expression to add an item TTW -->
+  <property name="add_view_expr">string:${folder_url}/++add++MaterialClassFolder</property>
+
+  <property name="link_target"/>
+  <property name="immediate_view">view</property>
+
+  <!-- Is this item addable globally, or is it restricted? -->
+  <property name="global_allow">True</property>
+
+  <!-- If we're a container, should we filter addable content types? -->
+  <property name="filter_content_types">True</property>
+  <!-- If filtering, what's allowed -->
+  <property name="allowed_content_types">
+    <element value="MaterialClass" />
+  </property>
+
+  <property name="allow_discussion">False</property>
+
+  <!-- what are our available view methods, and what's the default? -->
+  <property name="default_view">view</property>
+  <!-- the view methods below will be selectable via the display tab -->
+  <property name="view_methods">
+    <element value="view"/>
+  </property>
+  <property name="default_view_fallback">False</property>
+
+  <!-- permission required to add an item of this type -->
+  <property name="add_permission">cmf.AddPortalContent</property>
+
+  <!-- Python class for content items of this sort -->
+  <property name="schema">bika.cement.content.materialclassfolder.IMaterialClassFolder</property>
+  <property name="klass">bika.cement.content.materialclassfolder.MaterialClassFolder</property>
+
+  <!-- Dexterity behaviours for this type -->
+  <property name="behaviors">
+    <element value="plone.app.content.interfaces.INameFromTitle"/>
+    <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
+  </property>
+
+  <!-- Action aliases -->
+  <alias from="(Default)" to="(dynamic view)"/>
+  <alias from="edit" to="@@edit"/>
+  <alias from="sharing" to="@@sharing"/>
+  <alias from="view" to="(selected layout)"/>
+
+  <!-- View -->
+  <action title="View"
+          action_id="view"
+          category="object"
+          condition_expr=""
+          description=""
+          icon_expr=""
+          link_target=""
+          url_expr="string:${object_url}"
+          visible="False">
+    <permission value="View"/>
+  </action>
+
+  <!-- Edit -->
+  <action title="Edit"
+          action_id="edit"
+          category="object"
+          condition_expr=""
+          description=""
+          icon_expr=""
+          link_target=""
+          url_expr="string:${object_url}/edit"
+          visible="False">
+    <permission value="Modify portal content"/>
+  </action>
+
+</object>
+

--- a/src/bika/cement/setuphandlers.py
+++ b/src/bika/cement/setuphandlers.py
@@ -43,6 +43,9 @@ def add_dexterity_setup_items(portal):
         ("materialtype_folder",
          "Material Types",
          "MaterialTypeFolder"),
+        ("materialclass_folder",
+         "Material Class",
+         "MaterialClassFolder"),
     ]
     setup = api.get_setup()
     add_dexterity_items(setup, items)

--- a/src/bika/cement/setuphandlers.py
+++ b/src/bika/cement/setuphandlers.py
@@ -44,7 +44,7 @@ def add_dexterity_setup_items(portal):
          "Material Types",
          "MaterialTypeFolder"),
         ("materialclass_folder",
-         "Material Class",
+         "Material Classes",
          "MaterialClassFolder"),
     ]
     setup = api.get_setup()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1059

## Current behavior before PR
A Material Class does not exist in LIMS setup and it has no view page with title and description.

## Desired behavior after PR is merged
A Material Class has been created in LIMS setup and it has a view page with title and description.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
