### PR TITLE
Add mix type content type

### DIFF
--- a/src/bika/cement/browser/controlpanel/configure.zcml
+++ b/src/bika/cement/browser/controlpanel/configure.zcml
@@ -29,4 +29,12 @@
       permission="senaite.core.permissions.ManageBika"
       layer="bika.cement.interfaces.IBikaCementLayer"/>
 
+  <!-- Mix Type Folder -->
+  <browser:page
+      for="bika.cement.content.mixtypefolder.IMixTypeFolder"
+      name="view"
+      class=".mixtypefolder.MixTypeFolderView"
+      permission="senaite.core.permissions.ManageBika"
+      layer="bika.cement.interfaces.IBikaCementLayer"/>
+
 </configure>

--- a/src/bika/cement/browser/controlpanel/mixtypefolder.py
+++ b/src/bika/cement/browser/controlpanel/mixtypefolder.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2023 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+import collections
+
+from bika.cement.config import _
+from bika.lims import api
+from bika.lims.utils import get_link_for
+from senaite.app.listing import ListingView
+from senaite.core.catalog import SETUP_CATALOG
+
+
+class MixTypeFolderView(ListingView):
+    """Displays all available sample containers in a table
+    """
+
+    def __init__(self, context, request):
+        super(MixTypeFolderView, self).__init__(context, request)
+
+        self.catalog = SETUP_CATALOG
+
+        self.contentFilter = {
+            "portal_type": "MixType",
+            "sort_on": "sortable_title",
+        }
+
+        self.context_actions = {
+            _("Add"): {
+                "url": "++add++MixType",
+                "icon": "++resource++bika.lims.images/add.png",
+            }}
+
+        t = self.context.translate
+        self.title = t(_("Mix Types"))
+        self.description = t(_(""))
+
+        self.show_select_column = True
+        self.pagesize = 25
+
+        self.columns = collections.OrderedDict((
+            ("title", {
+                "title": _("Title"),
+                "index": "sortable_title"}),
+            ("description", {
+                "title": _("Description"),
+                "index": "description"}),
+        ))
+
+        self.review_states = [
+            {
+                "id": "default",
+                "title": _("Active"),
+                "contentFilter": {"is_active": True},
+                "columns": self.columns.keys(),
+            }, {
+                "id": "inactive",
+                "title": _("Inactive"),
+                "contentFilter": {'is_active': False},
+                "columns": self.columns.keys(),
+            }, {
+                "id": "all",
+                "title": _("All"),
+                "contentFilter": {},
+                "columns": self.columns.keys(),
+            },
+        ]
+
+    def folderitem(self, obj, item, index):
+        """Service triggered each time an item is iterated in folderitems.
+        The use of this service prevents the extra-loops in child objects.
+
+        :obj: the instance of the class to be foldered
+        :item: dict containing the properties of the object to be used by
+            the template
+        :index: current index of the item
+        """
+        obj = api.get_object(obj)
+
+        item["replace"]["title"] = get_link_for(obj)
+        item["description"] = api.get_description(obj)
+
+        return item

--- a/src/bika/cement/content/mixtype.py
+++ b/src/bika/cement/content/mixtype.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+from AccessControl import ClassSecurityInfo
+from bika.lims.interfaces import IDeactivable
+from plone.dexterity.content import Container
+from plone.supermodel import model
+from senaite.core.catalog import SETUP_CATALOG
+from senaite import api
+from zope import schema
+from zope.interface import implementer
+
+
+class IMixType(model.Schema):
+    """Marker interface and Dexterity Python Schema for Curing Methods"""
+
+    title = schema.TextLine(
+        title=u"Title",
+        required=False,
+    )
+
+    description = schema.Text(
+        title=u"Description",
+        required=False,
+    )
+
+
+@implementer(IMixType, IDeactivable)
+class MixType(Container):
+    """Content-type class for IMixType"""
+
+    _catalogs = [SETUP_CATALOG]
+
+    security = ClassSecurityInfo()
+
+    @security.private
+    def accessor(self, fieldname):
+        """Return the field accessor for the fieldname"""
+        schema = api.get_schema(self)
+        if fieldname not in schema:
+            return None
+        return schema[fieldname].get
+
+    @security.private
+    def mutator(self, fieldname):
+        """Return the field mutator for the fieldname"""
+        schema = api.get_schema(self)
+        if fieldname not in schema:
+            return None
+        result = schema[fieldname].set
+        self.reindexObject()
+        return result

--- a/src/bika/cement/content/mixtypefolder.py
+++ b/src/bika/cement/content/mixtypefolder.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2023 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from plone.dexterity.content import Container
+from plone.supermodel import model
+from zope.interface import implementer
+
+from bika.cement.interfaces import IMixTypeFolder
+from senaite.core.interfaces import IHideActionsMenu
+
+
+class IMixTypeFolderSchema(model.Schema):
+    """Schema interface
+    """
+
+
+@implementer(IMixTypeFolder, IMixTypeFolderSchema, IHideActionsMenu)
+class MixTypeFolder(Container):
+    """A folder/container for material types
+    """

--- a/src/bika/cement/interfaces.py
+++ b/src/bika/cement/interfaces.py
@@ -21,5 +21,10 @@ class IMaterialClassFolder(Interface):
 
 
 class ICuringMethodFolder(Interface):
-    """Marker interface for material type setup folder
+    """Marker interface for curing meethod setup folder
+    """
+
+
+class IMixTypeFolder(Interface):
+    """Marker interface for mix type setup folder
     """

--- a/src/bika/cement/profiles/default/types.xml
+++ b/src/bika/cement/profiles/default/types.xml
@@ -8,9 +8,13 @@
   <object name="MaterialClass" meta_type="Dexterity FTI"/>
   <object name="MaterialClassFolder" meta_type="Dexterity FTI"/>
 
-  <!-- Curing Methods-->
+  <!-- Curing Methods -->
   <object name="CuringMethod" meta_type="Dexterity FTI" />
   <object name="CuringMethodFolder" meta_type="Dexterity FTI" />
+
+  <!-- Mix Types -->
+  <object name="MixType" meta_type="Dexterity FTI" />
+  <object name="MixTypeFolder" meta_type="Dexterity FTI" />
 
 </object>
 

--- a/src/bika/cement/profiles/default/types/MixType.xml
+++ b/src/bika/cement/profiles/default/types/MixType.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    name="MixType"
+    meta_type="Dexterity FTI"
+    i18n:domain="bika.cement">
+
+  <!-- Basic properties -->
+  <property
+      i18n:translate=""
+      name="title">Mix Types</property>
+  <property
+      i18n:translate=""
+      name="description">Mix Types</property>
+
+  <property name="allow_discussion">False</property>
+  <property name="factory">MixType</property>
+  <property name="icon_expr"></property>
+  <property name="link_target"></property>
+
+  <!-- Hierarchy control -->
+  <property name="global_allow">False</property>
+  <property name="filter_content_types">True</property>
+  <!-- Schema, class and security -->
+  <property name="add_permission">cmf.AddPortalContent</property>
+  <property name="klass">bika.cement.content.mixtype.MixType</property>
+  <property name="model_file"></property>
+  <property name="model_source"></property>
+  <property name="schema">bika.cement.content.mixtype.IMixType</property>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors" purge="false">
+    <element value="bika.lims.interfaces.IAutoGenerateID"/>
+    <element value="bika.lims.interfaces.IMultiCatalogBehavior"/>
+    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
+  </property>
+
+  <!-- View information -->
+  <property name="add_view_expr">string:${folder_url}/++add++MixType</property>
+  <property name="default_view">view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="immediate_view">view</property>
+  <property name="view_methods">
+    <element value="view"/>
+  </property>
+
+  <!-- Method aliases -->
+  <alias
+      from="(Default)"
+      to="(dynamic view)"
+  />
+  <alias
+      from="edit"
+      to="@@edit"
+  />
+  <alias
+      from="sharing"
+      to="@@sharing"
+  />
+  <alias
+      from="view"
+      to="(selected layout)"
+  />
+
+  <!-- Actions -->
+  <action
+      action_id="view"
+      category="object"
+      condition_expr=""
+      i18n:attributes="title"
+      i18n:domain="plone"
+      title="View"
+      url_expr="string:${object_url}"
+      visible="True">
+    <permission value="View"/>
+  </action>
+  <action
+      action_id="edit"
+      category="object"
+      condition_expr=""
+      i18n:attributes="title"
+      i18n:domain="plone"
+      title="Edit"
+      url_expr="string:${object_url}/edit"
+      visible="True">
+    <permission value="Modify portal content"/>
+  </action>
+
+</object>

--- a/src/bika/cement/profiles/default/types/MixTypeFolder.xml
+++ b/src/bika/cement/profiles/default/types/MixTypeFolder.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<object name="MixTypeFolder" meta_type="Dexterity FTI"
+        i18n:domain="bika.cement"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <!-- Title and Description -->
+  <property name="title"
+            i18n:translate="">Mix Types</property>
+  <property name="description"
+            i18n:translate=""></property>
+
+  <!-- content-type icon -->
+  <property name="icon_expr">senaite_theme/icon/container</property>
+
+  <!-- factory name; usually the same as type name -->
+  <property name="factory">MixTypeFolder</property>
+
+  <!-- URL TALES expression to add an item TTW -->
+  <property name="add_view_expr">string:${folder_url}/++add++MixTypeFolder</property>
+
+  <property name="link_target"/>
+  <property name="immediate_view">view</property>
+
+  <!-- Is this item addable globally, or is it restricted? -->
+  <property name="global_allow">True</property>
+
+  <!-- If we're a container, should we filter addable content types? -->
+  <property name="filter_content_types">True</property>
+  <!-- If filtering, what's allowed -->
+  <property name="allowed_content_types">
+    <element value="MixType" />
+  </property>
+
+  <property name="allow_discussion">False</property>
+
+  <!-- what are our available view methods, and what's the default? -->
+  <property name="default_view">view</property>
+  <!-- the view methods below will be selectable via the display tab -->
+  <property name="view_methods">
+    <element value="view"/>
+  </property>
+  <property name="default_view_fallback">False</property>
+
+  <!-- permission required to add an item of this type -->
+  <property name="add_permission">cmf.AddPortalContent</property>
+
+  <!-- Python class for content items of this sort -->
+  <property name="schema">bika.cement.content.mixtypefolder.IMixTypeFolder</property>
+  <property name="klass">bika.cement.content.mixtypefolder.MixTypeFolder</property>
+
+  <!-- Dexterity behaviours for this type -->
+  <property name="behaviors">
+    <element value="plone.app.content.interfaces.INameFromTitle"/>
+  </property>
+
+  <!-- Action aliases -->
+  <alias from="(Default)" to="(dynamic view)"/>
+  <alias from="edit" to="@@edit"/>
+  <alias from="sharing" to="@@sharing"/>
+  <alias from="view" to="(selected layout)"/>
+
+  <!-- View -->
+  <action title="View"
+          action_id="view"
+          category="object"
+          condition_expr=""
+          description=""
+          icon_expr=""
+          link_target=""
+          url_expr="string:${object_url}"
+          visible="False">
+    <permission value="View"/>
+  </action>
+
+  <!-- Edit -->
+  <action title="Edit"
+          action_id="edit"
+          category="object"
+          condition_expr=""
+          description=""
+          icon_expr=""
+          link_target=""
+          url_expr="string:${object_url}/edit"
+          visible="False">
+    <permission value="Modify portal content"/>
+  </action>
+
+</object>
+

--- a/src/bika/cement/setuphandlers.py
+++ b/src/bika/cement/setuphandlers.py
@@ -49,6 +49,9 @@ def add_dexterity_setup_items(portal):
         ("curingmethod_folder",
          "Curing Methods",
          "CuringMethodFolder"),
+        ("mixtype_folder",
+         "Mix Types",
+         "MixTypeFolder"),
     ]
     setup = api.get_setup()
     add_dexterity_items(setup, items)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1057

## Current behavior before PR

No mixed type container and content type.

## Desired behavior after PR is merged

- A mix type container has been added in the LIMS Setup. 

- A mix type content type with title and description attributes.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
