### PR TITLE
Add sort order to material classes

### DIFF
--- a/src/bika/cement/browser/controlpanel/materialclassfolder.py
+++ b/src/bika/cement/browser/controlpanel/materialclassfolder.py
@@ -54,6 +54,9 @@ class MaterialClassFolderView(ListingView):
         self.pagesize = 25
 
         self.columns = collections.OrderedDict((
+            ("sortOrder", {
+                "title": _("Sort Order"),
+                "index": "sortOrder"}),
             ("title", {
                 "title": _("Title"),
                 "index": "sortable_title"}),
@@ -94,5 +97,6 @@ class MaterialClassFolderView(ListingView):
 
         item["replace"]["title"] = get_link_for(obj)
         item["description"] = api.get_description(obj)
+        item["sortOrder"] = obj.sortOrder
 
         return item

--- a/src/bika/cement/browser/controlpanel/materialclassfolder.py
+++ b/src/bika/cement/browser/controlpanel/materialclassfolder.py
@@ -38,6 +38,7 @@ class MaterialClassFolderView(ListingView):
         self.contentFilter = {
             "portal_type": "MaterialClass",
             "sort_on": "sort_key",
+            "sort_order": "ascending",
         }
 
         self.context_actions = {

--- a/src/bika/cement/browser/controlpanel/materialclassfolder.py
+++ b/src/bika/cement/browser/controlpanel/materialclassfolder.py
@@ -37,7 +37,7 @@ class MaterialClassFolderView(ListingView):
 
         self.contentFilter = {
             "portal_type": "MaterialClass",
-            "sort_on": "sortable_title",
+            "sort_on": "sort_key",
         }
 
         self.context_actions = {
@@ -54,9 +54,9 @@ class MaterialClassFolderView(ListingView):
         self.pagesize = 25
 
         self.columns = collections.OrderedDict((
-            ("sortOrder", {
-                "title": _("Sort Order"),
-                "index": "sortOrder"}),
+            ("sort_key", {
+                "title": _("Sort Key"),
+                "index": "sort_key"}),
             ("title", {
                 "title": _("Title"),
                 "index": "sortable_title"}),
@@ -97,6 +97,6 @@ class MaterialClassFolderView(ListingView):
 
         item["replace"]["title"] = get_link_for(obj)
         item["description"] = api.get_description(obj)
-        item["sortOrder"] = obj.sortOrder
+        item["sort_key"] = obj.sort_key
 
         return item

--- a/src/bika/cement/content/materialclass.py
+++ b/src/bika/cement/content/materialclass.py
@@ -7,10 +7,26 @@ from plone.supermodel import model
 from senaite.core.catalog import SETUP_CATALOG
 from senaite import api
 from zope.interface import implementer
+from zope import schema
 
 
 class IMaterialClass(model.Schema):
     """Marker interface and Dexterity Python Schema for MaterialClass"""
+
+    title = schema.TextLine(
+        title=u"Title",
+        required=True,
+    )
+
+    description = schema.Text(
+        title=u"Description",
+        required=False,
+    )
+
+    sortOrder = schema.Int(
+        title=u"Sort Order",
+        required=False,
+    )
 
 
 @implementer(IMaterialClass, IDeactivable)

--- a/src/bika/cement/content/materialclass.py
+++ b/src/bika/cement/content/materialclass.py
@@ -23,9 +23,9 @@ class IMaterialClass(model.Schema):
         required=False,
     )
 
-    sortOrder = schema.Int(
-        title=u"Sort Order",
-        required=False,
+    sort_key = schema.Int(
+        title=u"Sort Key",
+        required=True,
     )
 
 

--- a/src/bika/cement/profiles/default/types/MaterialClass.xml
+++ b/src/bika/cement/profiles/default/types/MaterialClass.xml
@@ -31,7 +31,6 @@
   <property name="behaviors" purge="false">
     <element value="bika.lims.interfaces.IAutoGenerateID"/>
     <element value="bika.lims.interfaces.IMultiCatalogBehavior"/>
-    <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
     <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
   </property>
 

--- a/src/bika/cement/profiles/default/types/MaterialClassFolder.xml
+++ b/src/bika/cement/profiles/default/types/MaterialClassFolder.xml
@@ -51,7 +51,6 @@
   <!-- Dexterity behaviours for this type -->
   <property name="behaviors">
     <element value="plone.app.content.interfaces.INameFromTitle"/>
-    <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
   </property>
 
   <!-- Action aliases -->

--- a/src/bika/cement/setuphandlers.py
+++ b/src/bika/cement/setuphandlers.py
@@ -4,7 +4,17 @@ from zope.interface import implementer
 from bika.cement.config import PROFILE_ID
 from bika.cement.config import logger
 from bika.lims import api
-from senaite.core.setuphandlers import add_dexterity_items
+from senaite.core.catalog import SETUP_CATALOG
+from senaite.core.setuphandlers import add_dexterity_items, setup_other_catalogs
+
+
+INDEXES = [
+    (SETUP_CATALOG, "sort_key", "", "FieldIndex"),
+]
+
+COLUMNS = [
+    (SETUP_CATALOG, "sort_key"),
+]
 
 
 @implementer(INonInstallable)
@@ -25,6 +35,7 @@ def post_install(context):
     context = context._getImportContext(profile_id)
     portal = context.getSite()
     add_dexterity_setup_items(portal)
+    setup_catalogs(portal)
 
 
 def uninstall(context):
@@ -55,3 +66,8 @@ def add_dexterity_setup_items(portal):
     ]
     setup = api.get_setup()
     add_dexterity_items(setup, items)
+
+
+def setup_catalogs(portal):
+    """Setup catalogs"""
+    setup_other_catalogs(portal, indexes=INDEXES, columns=COLUMNS)

--- a/src/bika/cement/setuphandlers.py
+++ b/src/bika/cement/setuphandlers.py
@@ -5,7 +5,10 @@ from bika.cement.config import PROFILE_ID
 from bika.cement.config import logger
 from bika.lims import api
 from senaite.core.catalog import SETUP_CATALOG
-from senaite.core.setuphandlers import add_dexterity_items, setup_other_catalogs
+from senaite.core.setuphandlers import (
+    add_dexterity_items,
+    setup_other_catalogs,
+)
 
 
 INDEXES = [
@@ -19,11 +22,10 @@ COLUMNS = [
 
 @implementer(INonInstallable)
 class HiddenProfiles(object):
-
     def getNonInstallableProfiles(self):
         """Hide uninstall profile from site-creation and quickinstaller."""
         return [
-            'bika.cement:uninstall',
+            "bika.cement:uninstall",
         ]
 
 
@@ -51,18 +53,10 @@ def add_dexterity_setup_items(portal):
     """
     # Tuples of ID, Title, FTI
     items = [
-        ("materialtype_folder",
-         "Material Types",
-         "MaterialTypeFolder"),
-        ("materialclass_folder",
-         "Material Classes",
-         "MaterialClassFolder"),
-        ("curingmethod_folder",
-         "Curing Methods",
-         "CuringMethodFolder"),
-        ("mixtype_folder",
-         "Mix Types",
-         "MixTypeFolder"),
+        ("materialtype_folder", "Material Types", "MaterialTypeFolder"),
+        ("materialclass_folder", "Material Classes", "MaterialClassFolder"),
+        ("curingmethod_folder", "Curing Methods", "CuringMethodFolder"),
+        ("mixtype_folder", "Mix Types", "MixTypeFolder"),
     ]
     setup = api.get_setup()
     add_dexterity_items(setup, items)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1059

## Current behavior before PR

No sort order on material classes

## Desired behavior after PR is merged

Sort order attribute added to material classes of type Int

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
