### PR TITLE
add material class drop down to material types

### DIFF
--- a/src/bika/cement/browser/controlpanel/materialtypefolder.py
+++ b/src/bika/cement/browser/controlpanel/materialtypefolder.py
@@ -22,14 +22,13 @@ import collections
 
 from bika.cement.config import _
 from bika.lims import api
-from bika.lims.utils import get_link_for
+from bika.lims.utils import get_link, get_link_for
 from senaite.app.listing import ListingView
 from senaite.core.catalog import SETUP_CATALOG
 
 
 class MaterialTypeFolderView(ListingView):
-    """Displays all available sample containers in a table
-    """
+    """Displays all available sample containers in a table"""
 
     def __init__(self, context, request):
         super(MaterialTypeFolderView, self).__init__(context, request)
@@ -45,7 +44,8 @@ class MaterialTypeFolderView(ListingView):
             _("Add"): {
                 "url": "++add++MaterialType",
                 "icon": "++resource++bika.lims.images/add.png",
-            }}
+            }
+        }
 
         t = self.context.translate
         self.title = t(_("Material Types"))
@@ -54,14 +54,19 @@ class MaterialTypeFolderView(ListingView):
         self.show_select_column = True
         self.pagesize = 25
 
-        self.columns = collections.OrderedDict((
-            ("title", {
-                "title": _("Title"),
-                "index": "sortable_title"}),
-            ("description", {
-                "title": _("Description"),
-                "index": "description"}),
-        ))
+        self.columns = collections.OrderedDict(
+            (
+                ("title", {"title": _("Title"), "index": "sortable_title"}),
+                (
+                    "MaterialClass",
+                    {"title": _("Material Class"), "index": "sortable_title"},
+                ),
+                (
+                    "description",
+                    {"title": _("Description"), "index": "description"},
+                ),
+            )
+        )
 
         self.review_states = [
             {
@@ -69,12 +74,14 @@ class MaterialTypeFolderView(ListingView):
                 "title": _("Active"),
                 "contentFilter": {"is_active": True},
                 "columns": self.columns.keys(),
-            }, {
+            },
+            {
                 "id": "inactive",
                 "title": _("Inactive"),
-                "contentFilter": {'is_active': False},
+                "contentFilter": {"is_active": False},
                 "columns": self.columns.keys(),
-            }, {
+            },
+            {
                 "id": "all",
                 "title": _("All"),
                 "contentFilter": {},
@@ -96,4 +103,14 @@ class MaterialTypeFolderView(ListingView):
         item["replace"]["title"] = get_link_for(obj)
         item["description"] = api.get_description(obj)
 
+        material_class_list = obj.MaterialClass
+        if material_class_list:
+            material_class_obj = api.get_object_by_uid(material_class_list[0])
+            material_class_title = material_class_obj.title
+            material_class_url = material_class_obj.absolute_url()
+            material_class_link = get_link(
+                material_class_url, material_class_title
+            )
+            item["MaterialClass"] = material_class_title
+            item["replace"]["MaterialClass"] = material_class_link
         return item

--- a/src/bika/cement/content/materialtype.py
+++ b/src/bika/cement/content/materialtype.py
@@ -6,11 +6,30 @@ from plone.dexterity.content import Container
 from plone.supermodel import model
 from senaite.core.catalog import SETUP_CATALOG
 from senaite import api
+from senaite.core.schema import UIDReferenceField
+from zope import schema
 from zope.interface import implementer
 
 
 class IMaterialType(model.Schema):
     """Marker interface and Dexterity Python Schema for Material Types"""
+
+    title = schema.TextLine(
+        title=u"Title",
+        required=True,
+    )
+
+    description = schema.Text(
+        title=u"Description",
+        required=False,
+    )
+
+    MaterialClass = UIDReferenceField(
+        title=u"Material Class",
+        allowed_types=("MaterialClass", ),
+        multi_valued=False,
+        required=False,
+    )
 
 
 @implementer(IMaterialType, IDeactivable)

--- a/src/bika/cement/profiles/default/types/MaterialType.xml
+++ b/src/bika/cement/profiles/default/types/MaterialType.xml
@@ -31,7 +31,6 @@
   <property name="behaviors" purge="false">
     <element value="bika.lims.interfaces.IAutoGenerateID"/>
     <element value="bika.lims.interfaces.IMultiCatalogBehavior"/>
-    <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
     <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
   </property>
 

--- a/src/bika/cement/profiles/default/types/MaterialTypeFolder.xml
+++ b/src/bika/cement/profiles/default/types/MaterialTypeFolder.xml
@@ -51,7 +51,6 @@
   <!-- Dexterity behaviours for this type -->
   <property name="behaviors">
     <element value="plone.app.content.interfaces.INameFromTitle"/>
-    <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
   </property>
 
   <!-- Action aliases -->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1060

## Current behavior before PR

Material Types do not have a material class attribute.

## Desired behavior after PR is merged

Material Types have a material class attribute in the form of a drop down list.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
