### PR TITLE
Add mix materials content type

### DIFF
--- a/src/bika/cement/browser/controlpanel/configure.zcml
+++ b/src/bika/cement/browser/controlpanel/configure.zcml
@@ -37,4 +37,12 @@
       permission="senaite.core.permissions.ManageBika"
       layer="bika.cement.interfaces.IBikaCementLayer"/>
 
+  <!-- Mix Material Folder -->
+  <browser:page
+      for="bika.cement.content.mixmaterialfolder.IMixMaterialFolder"
+      name="view"
+      class=".mixmaterialfolder.MixMaterialFolderView"
+      permission="senaite.core.permissions.ManageBika"
+      layer="bika.cement.interfaces.IBikaCementLayer"/>
+
 </configure>

--- a/src/bika/cement/browser/controlpanel/mixmaterialfolder.py
+++ b/src/bika/cement/browser/controlpanel/mixmaterialfolder.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2023 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+import collections
+
+from bika.cement.config import _
+from bika.lims import api
+from bika.lims.utils import get_link, get_link_for
+from senaite.app.listing import ListingView
+from senaite.core.catalog import SETUP_CATALOG
+
+
+class MixMaterialFolderView(ListingView):
+    """Displays all available sample containers in a table
+    """
+
+    def __init__(self, context, request):
+        super(MixMaterialFolderView, self).__init__(context, request)
+
+        self.catalog = SETUP_CATALOG
+
+        self.contentFilter = {
+            "portal_type": "MixMaterial",
+            "sort_on": "sortable_title",
+        }
+
+        self.context_actions = {
+            _("Add"): {
+                "url": "++add++MixMaterial",
+                "icon": "++resource++bika.lims.images/add.png",
+            }}
+
+        t = self.context.translate
+        self.title = t(_("Mix Materials"))
+        self.description = t(_(""))
+
+        self.show_select_column = True
+        self.pagesize = 25
+
+        self.columns = collections.OrderedDict((
+            ("title", {
+                "title": _("Title"),
+                "index": "sortable_title"}),
+            ("materialType", {
+                "title": _("Material Type"),
+                "index": "material_type"}),
+            ("Manufacturer", {
+                "title": _("Manufacturer"),
+                "index": "sortable_title"}),
+            ("Supplier", {
+                "title": _("Supplier"),
+                "index": "sortable_title"}),
+            ("description", {
+                "title": _("Description"),
+                "index": "description"}),
+            ("specificGravity", {
+                "title": _("Specific Gravity"),
+                "index": "specific_gravity"}),
+            ("absorptionRate", {
+                "title": _("Absorption Rate"),
+                "index": "absorption_rate"}),
+        ))
+
+        self.review_states = [
+            {
+                "id": "default",
+                "title": _("Active"),
+                "contentFilter": {"is_active": True},
+                "columns": self.columns.keys(),
+            }, {
+                "id": "inactive",
+                "title": _("Inactive"),
+                "contentFilter": {'is_active': False},
+                "columns": self.columns.keys(),
+            }, {
+                "id": "all",
+                "title": _("All"),
+                "contentFilter": {},
+                "columns": self.columns.keys(),
+            },
+        ]
+
+    def folderitem(self, obj, item, index):
+        """Service triggered each time an item is iterated in folderitems.
+        The use of this service prevents the extra-loops in child objects.
+
+        :obj: the instance of the class to be foldered
+        :item: dict containing the properties of the object to be used by
+            the template
+        :index: current index of the item
+        """
+        obj = api.get_object(obj)
+
+        item["replace"]["title"] = get_link_for(obj)
+        item["description"] = api.get_description(obj)
+        item["specificGravity"] = obj.specific_gravity
+        item["absorptionRate"] = obj.absorption_rate
+
+        # Manufacturer
+        manufacturer_list = obj.manufacturer
+        if manufacturer_list:
+            manufacturer_obj = api.get_object_by_uid(manufacturer_list[0])
+            manufacturer_title = manufacturer_obj.title
+            manufacturer_url = manufacturer_obj.absolute_url()
+            manufacturer_link = get_link(
+                manufacturer_url, manufacturer_title
+            )
+            item["Manufacturer"] = manufacturer_title
+            item["replace"]["Manufacturer"] = manufacturer_link
+
+        # Supplier
+        supplier_list = obj.supplier
+        if supplier_list:
+            supplier_obj = api.get_object_by_uid(supplier_list[0])
+            supplier_title = supplier_obj.title
+            supplier_url = supplier_obj.absolute_url()
+            supplier_link = get_link(
+                supplier_url, supplier_title
+            )
+            item["Supplier"] = supplier_link
+            item["replace"]["Supplier"] = supplier_link
+
+        # Material Type
+        material_type_list = obj.material_type
+        if material_type_list:
+            material_type_obj = api.get_object_by_uid(material_type_list[0])
+            material_type_title = material_type_obj.title
+            material_type_url = material_type_obj.absolute_url()
+            material_type_link = get_link(
+                material_type_url, material_type_title
+            )
+            item["materialType"] = material_type_link
+            item["replace"]["materialType"] = material_type_link
+
+        return item

--- a/src/bika/cement/browser/controlpanel/mixmaterialfolder.py
+++ b/src/bika/cement/browser/controlpanel/mixmaterialfolder.py
@@ -58,22 +58,22 @@ class MixMaterialFolderView(ListingView):
             ("title", {
                 "title": _("Title"),
                 "index": "sortable_title"}),
-            ("materialType", {
+            ("material_type", {
                 "title": _("Material Type"),
                 "index": "material_type"}),
-            ("Manufacturer", {
+            ("manufacturer", {
                 "title": _("Manufacturer"),
                 "index": "sortable_title"}),
-            ("Supplier", {
+            ("supplier", {
                 "title": _("Supplier"),
                 "index": "sortable_title"}),
             ("description", {
                 "title": _("Description"),
                 "index": "description"}),
-            ("specificGravity", {
+            ("specific_gravity", {
                 "title": _("Specific Gravity"),
                 "index": "specific_gravity"}),
-            ("absorptionRate", {
+            ("absorption_rate", {
                 "title": _("Absorption Rate"),
                 "index": "absorption_rate"}),
         ))
@@ -110,8 +110,8 @@ class MixMaterialFolderView(ListingView):
 
         item["replace"]["title"] = get_link_for(obj)
         item["description"] = api.get_description(obj)
-        item["specificGravity"] = obj.specific_gravity
-        item["absorptionRate"] = obj.absorption_rate
+        item["specific_gravity"] = obj.specific_gravity
+        item["absorption_rate"] = obj.absorption_rate
 
         # Manufacturer
         manufacturer_list = obj.manufacturer
@@ -122,8 +122,8 @@ class MixMaterialFolderView(ListingView):
             manufacturer_link = get_link(
                 manufacturer_url, manufacturer_title
             )
-            item["Manufacturer"] = manufacturer_title
-            item["replace"]["Manufacturer"] = manufacturer_link
+            item["manufacturer"] = manufacturer_title
+            item["replace"]["manufacturer"] = manufacturer_link
 
         # Supplier
         supplier_list = obj.supplier
@@ -134,8 +134,8 @@ class MixMaterialFolderView(ListingView):
             supplier_link = get_link(
                 supplier_url, supplier_title
             )
-            item["Supplier"] = supplier_link
-            item["replace"]["Supplier"] = supplier_link
+            item["supplier"] = supplier_title
+            item["replace"]["supplier"] = supplier_link
 
         # Material Type
         material_type_list = obj.material_type
@@ -146,7 +146,7 @@ class MixMaterialFolderView(ListingView):
             material_type_link = get_link(
                 material_type_url, material_type_title
             )
-            item["materialType"] = material_type_link
-            item["replace"]["materialType"] = material_type_link
+            item["material_type"] = material_type_title
+            item["replace"]["material_type"] = material_type_link
 
         return item

--- a/src/bika/cement/content/mixmaterial.py
+++ b/src/bika/cement/content/mixmaterial.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+
+from AccessControl import ClassSecurityInfo
+from bika.lims.interfaces import IDeactivable
+from plone.dexterity.content import Container
+from plone.supermodel import model
+from senaite.core.catalog import SETUP_CATALOG
+from senaite import api
+from zope.interface import implementer
+
+from zope import schema
+from senaite.core.schema import UIDReferenceField
+
+
+class IMixMaterial(model.Schema):
+    """Marker interface and Dexterity Python Schema for Mix Material"""
+
+    # add basic things here
+    title = schema.TextLine(
+        title=u"Title",
+        required=True,
+    )
+
+    description = schema.Text(
+        title=u"Description",
+        required=False,
+    )
+
+    specific_gravity = schema.Decimal(
+        title=u"Specific Gravity",
+        required=False,
+    )
+
+    absorption_rate = schema.Decimal(
+        title=u"Absorption Rate",
+        required=False,
+    )
+
+    manufacturer = UIDReferenceField(
+        title=u"Manufacturer",
+        allowed_types=("Manufacturer", ),
+        multi_valued=False,
+        required=False,
+    )
+
+    supplier = UIDReferenceField(
+        title=u"Supplier",
+        allowed_types=("Supplier", ),
+        multi_valued=False,
+        required=False,
+    )
+
+    material_type = UIDReferenceField(
+        title=u"Material Type",
+        allowed_types=("MaterialType", ),
+        multi_valued=False,
+        required=False,
+    )
+
+
+@implementer(IMixMaterial, IDeactivable)
+class MixMaterial(Container):
+    """Content-type class for IMixMaterial"""
+
+    _catalogs = [SETUP_CATALOG]
+
+    security = ClassSecurityInfo()
+
+    @security.private
+    def accessor(self, fieldname):
+        """Return the field accessor for the fieldname"""
+        schema = api.get_schema(self)
+        if fieldname not in schema:
+            return None
+        return schema[fieldname].get
+
+    @security.private
+    def mutator(self, fieldname):
+        """Return the field mutator for the fieldname"""
+        schema = api.get_schema(self)
+        if fieldname not in schema:
+            return None
+        result = schema[fieldname].set
+        self.reindexObject()
+        return result

--- a/src/bika/cement/content/mixmaterialfolder.py
+++ b/src/bika/cement/content/mixmaterialfolder.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2023 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from plone.dexterity.content import Container
+from plone.supermodel import model
+from zope.interface import implementer
+
+from bika.cement.interfaces import IMixMaterialFolder
+from senaite.core.interfaces import IHideActionsMenu
+
+
+class IMixMaterialFolderSchema(model.Schema):
+    """Schema interface
+    """
+
+
+@implementer(IMixMaterialFolder, IMixMaterialFolderSchema, IHideActionsMenu)
+class MixMaterialFolder(Container):
+    """A folder/container for material types
+    """

--- a/src/bika/cement/interfaces.py
+++ b/src/bika/cement/interfaces.py
@@ -28,3 +28,8 @@ class ICuringMethodFolder(Interface):
 class IMixTypeFolder(Interface):
     """Marker interface for mix type setup folder
     """
+
+
+class IMixMaterialFolder(Interface):
+    """Marker interface for mix type setup folder
+    """

--- a/src/bika/cement/profiles/default/types.xml
+++ b/src/bika/cement/profiles/default/types.xml
@@ -5,6 +5,8 @@
   <!-- Material Types -->
   <object name="MaterialType" meta_type="Dexterity FTI" />
   <object name="MaterialTypeFolder" meta_type="Dexterity FTI" />
+
+  <!-- Material Classes -->
   <object name="MaterialClass" meta_type="Dexterity FTI"/>
   <object name="MaterialClassFolder" meta_type="Dexterity FTI"/>
 
@@ -15,6 +17,10 @@
   <!-- Mix Types -->
   <object name="MixType" meta_type="Dexterity FTI" />
   <object name="MixTypeFolder" meta_type="Dexterity FTI" />
+
+  <!-- Mix Materials -->
+  <object name="MixMaterial" meta_type="Dexterity FTI" />
+  <object name="MixMaterialFolder" meta_type="Dexterity FTI" />
 
 </object>
 

--- a/src/bika/cement/profiles/default/types/MixMaterial.xml
+++ b/src/bika/cement/profiles/default/types/MixMaterial.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    name="MixMaterial"
+    meta_type="Dexterity FTI"
+    i18n:domain="bika.cement">
+
+  <!-- Basic properties -->
+  <property
+      i18n:translate=""
+      name="title">Mix Material</property>
+  <property
+      i18n:translate=""
+      name="description">Mix Materials</property>
+
+  <property name="allow_discussion">False</property>
+  <property name="factory">MixMaterial</property>
+  <property name="icon_expr"></property>
+  <property name="link_target"></property>
+
+  <!-- Hierarchy control -->
+  <property name="global_allow">False</property>
+  <property name="filter_content_types">True</property>
+  <!-- Schema, class and security -->
+  <property name="add_permission">cmf.AddPortalContent</property>
+  <property name="klass">bika.cement.content.mixmaterial.MixMaterial</property>
+  <property name="model_file"></property>
+  <property name="model_source"></property>
+  <property name="schema">bika.cement.content.mixmaterial.IMixMaterial</property>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors" purge="false">
+    <element value="bika.lims.interfaces.IAutoGenerateID"/>
+    <element value="bika.lims.interfaces.IMultiCatalogBehavior"/>
+    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
+  </property>
+
+  <!-- View information -->
+  <property name="add_view_expr">string:${folder_url}/++add++MixMaterial</property>
+  <property name="default_view">view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="immediate_view">view</property>
+  <property name="view_methods">
+    <element value="view"/>
+  </property>
+
+  <!-- Method aliases -->
+  <alias
+      from="(Default)"
+      to="(dynamic view)"
+  />
+  <alias
+      from="edit"
+      to="@@edit"
+  />
+  <alias
+      from="sharing"
+      to="@@sharing"
+  />
+  <alias
+      from="view"
+      to="(selected layout)"
+  />
+
+  <!-- Actions -->
+  <action
+      action_id="view"
+      category="object"
+      condition_expr=""
+      i18n:attributes="title"
+      i18n:domain="plone"
+      title="View"
+      url_expr="string:${object_url}"
+      visible="True">
+    <permission value="View"/>
+  </action>
+  <action
+      action_id="edit"
+      category="object"
+      condition_expr=""
+      i18n:attributes="title"
+      i18n:domain="plone"
+      title="Edit"
+      url_expr="string:${object_url}/edit"
+      visible="True">
+    <permission value="Modify portal content"/>
+  </action>
+
+</object>

--- a/src/bika/cement/profiles/default/types/MixMaterialFolder.xml
+++ b/src/bika/cement/profiles/default/types/MixMaterialFolder.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<object name="MixMaterialFolder" meta_type="Dexterity FTI"
+        i18n:domain="bika.cement"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <!-- Title and Description -->
+  <property name="title"
+            i18n:translate="">Mix Material</property>
+  <property name="description"
+            i18n:translate=""></property>
+
+  <!-- content-type icon -->
+  <property name="icon_expr">senaite_theme/icon/container</property>
+
+  <!-- factory name; usually the same as type name -->
+  <property name="factory">MixMaterialFolder</property>
+
+  <!-- URL TALES expression to add an item TTW -->
+  <property name="add_view_expr">string:${folder_url}/++add++MixMaterialFolder</property>
+
+  <property name="link_target"/>
+  <property name="immediate_view">view</property>
+
+  <!-- Is this item addable globally, or is it restricted? -->
+  <property name="global_allow">True</property>
+
+  <!-- If we're a container, should we filter addable content types? -->
+  <property name="filter_content_types">True</property>
+  <!-- If filtering, what's allowed -->
+  <property name="allowed_content_types">
+    <element value="MixMaterial" />
+  </property>
+
+  <property name="allow_discussion">False</property>
+
+  <!-- what are our available view methods, and what's the default? -->
+  <property name="default_view">view</property>
+  <!-- the view methods below will be selectable via the display tab -->
+  <property name="view_methods">
+    <element value="view"/>
+  </property>
+  <property name="default_view_fallback">False</property>
+
+  <!-- permission required to add an item of this type -->
+  <property name="add_permission">cmf.AddPortalContent</property>
+
+  <!-- Python class for content items of this sort -->
+  <property name="schema">bika.cement.content.mixmaterialfolder.IMixMaterialFolder</property>
+  <property name="klass">bika.cement.content.mixmaterialfolder.MixMaterialFolder</property>
+
+  <!-- Dexterity behaviours for this type -->
+  <property name="behaviors">
+    <element value="plone.app.content.interfaces.INameFromTitle"/>
+  </property>
+
+  <!-- Action aliases -->
+  <alias from="(Default)" to="(dynamic view)"/>
+  <alias from="edit" to="@@edit"/>
+  <alias from="sharing" to="@@sharing"/>
+  <alias from="view" to="(selected layout)"/>
+
+  <!-- View -->
+  <action title="View"
+          action_id="view"
+          category="object"
+          condition_expr=""
+          description=""
+          icon_expr=""
+          link_target=""
+          url_expr="string:${object_url}"
+          visible="False">
+    <permission value="View"/>
+  </action>
+
+  <!-- Edit -->
+  <action title="Edit"
+          action_id="edit"
+          category="object"
+          condition_expr=""
+          description=""
+          icon_expr=""
+          link_target=""
+          url_expr="string:${object_url}/edit"
+          visible="False">
+    <permission value="Modify portal content"/>
+  </action>
+
+</object>
+

--- a/src/bika/cement/setuphandlers.py
+++ b/src/bika/cement/setuphandlers.py
@@ -57,6 +57,7 @@ def add_dexterity_setup_items(portal):
         ("materialclass_folder", "Material Classes", "MaterialClassFolder"),
         ("curingmethod_folder", "Curing Methods", "CuringMethodFolder"),
         ("mixtype_folder", "Mix Types", "MixTypeFolder"),
+        ("mixmaterial_folder", "Mix Materials", "MixMaterialFolder"),
     ]
     setup = api.get_setup()
     add_dexterity_items(setup, items)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1056

## Current behavior before PR
No mix materials container and content type.

## Desired behavior after PR is merged

- A mix materials  container has been added in the LIMS Setup. 

- A mix materials content type with title, material type, manufacturer, supplier, description, specific gravity and absorption rate attributes.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
