### PR TITLE
Rename Curing Method Folder and move to senaite setup

### DIFF
--- a/src/bika/cement/browser/controlpanel/configure.zcml
+++ b/src/bika/cement/browser/controlpanel/configure.zcml
@@ -15,9 +15,9 @@
       
   <!-- Curing Method Folder -->
   <browser:page
-      for="bika.cement.content.curingmethodfolder.ICuringMethodFolder"
+      for="bika.cement.content.curingmethods.ICuringMethods"
       name="view"
-      class=".curingmethodfolder.CuringMethodFolderView"
+      class=".curingmethods.CuringMethodsView"
       permission="senaite.core.permissions.ManageBika"
       layer="bika.cement.interfaces.IBikaCementLayer"/>
 

--- a/src/bika/cement/browser/controlpanel/curingmethods.py
+++ b/src/bika/cement/browser/controlpanel/curingmethods.py
@@ -27,12 +27,12 @@ from senaite.app.listing import ListingView
 from senaite.core.catalog import SETUP_CATALOG
 
 
-class CuringMethodFolderView(ListingView):
+class CuringMethodsView(ListingView):
     """Displays all available sample containers in a table
     """
 
     def __init__(self, context, request):
-        super(CuringMethodFolderView, self).__init__(context, request)
+        super(CuringMethodsView, self).__init__(context, request)
 
         self.catalog = SETUP_CATALOG
 

--- a/src/bika/cement/content/curingmethod.py
+++ b/src/bika/cement/content/curingmethod.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from AccessControl import ClassSecurityInfo
+from bika.cement.interfaces import ICuringMethod
 from bika.lims.interfaces import IDeactivable
 from plone.dexterity.content import Container
 from plone.supermodel import model
@@ -10,7 +11,7 @@ from zope import schema
 from zope.interface import implementer
 
 
-class ICuringMethod(model.Schema):
+class ICuringMethodSchema(model.Schema):
     """Marker interface and Dexterity Python Schema for Curing Methods"""
 
     title = schema.TextLine(
@@ -24,7 +25,7 @@ class ICuringMethod(model.Schema):
     )
 
 
-@implementer(ICuringMethod, IDeactivable)
+@implementer(ICuringMethod, ICuringMethodSchema, IDeactivable)
 class CuringMethod(Container):
     """Content-type class for ICuringMethod"""
 

--- a/src/bika/cement/content/curingmethods.py
+++ b/src/bika/cement/content/curingmethods.py
@@ -22,16 +22,16 @@ from plone.dexterity.content import Container
 from plone.supermodel import model
 from zope.interface import implementer
 
-from bika.cement.interfaces import ICuringMethodFolder
+from bika.cement.interfaces import ICuringMethods
 from senaite.core.interfaces import IHideActionsMenu
 
 
-class ICuringMethodFolderSchema(model.Schema):
+class ICuringMethodsSchema(model.Schema):
     """Schema interface
     """
 
 
-@implementer(ICuringMethodFolder, ICuringMethodFolderSchema, IHideActionsMenu)
-class CuringMethodFolder(Container):
+@implementer(ICuringMethods, ICuringMethodsSchema, IHideActionsMenu)
+class CuringMethods(Container):
     """A folder/container for material types
     """

--- a/src/bika/cement/interfaces.py
+++ b/src/bika/cement/interfaces.py
@@ -11,22 +11,27 @@ class IBikaCementLayer(IDefaultBrowserLayer):
 
 
 class IMaterialTypeFolder(Interface):
-    """Marker interface for material type setup folder
+    """Marker interface for material types setup folder
     """
 
 
 class IMaterialClassFolder(Interface):
-    """Marker interface for material class setup folder
+    """Marker interface for material classes setup folder
     """
 
 
-class ICuringMethodFolder(Interface):
-    """Marker interface for curing meethod setup folder
+class ICuringMethod(Interface):
+    """Marker interface for curing methods
+    """
+
+
+class ICuringMethods(Interface):
+    """Marker interface for curing methods setup folder
     """
 
 
 class IMixTypeFolder(Interface):
-    """Marker interface for mix type setup folder
+    """Marker interface for mix types setup foler
     """
 
 

--- a/src/bika/cement/interfaces.py
+++ b/src/bika/cement/interfaces.py
@@ -31,7 +31,7 @@ class ICuringMethods(Interface):
 
 
 class IMixTypeFolder(Interface):
-    """Marker interface for mix types setup foler
+    """Marker interface for mix types setup folder
     """
 
 

--- a/src/bika/cement/profiles/default/types.xml
+++ b/src/bika/cement/profiles/default/types.xml
@@ -12,7 +12,7 @@
 
   <!-- Curing Methods -->
   <object name="CuringMethod" meta_type="Dexterity FTI" />
-  <object name="CuringMethodFolder" meta_type="Dexterity FTI" />
+  <object name="CuringMethods" meta_type="Dexterity FTI" />
 
   <!-- Mix Types -->
   <object name="MixType" meta_type="Dexterity FTI" />

--- a/src/bika/cement/profiles/default/types/CuringMethod.xml
+++ b/src/bika/cement/profiles/default/types/CuringMethod.xml
@@ -7,10 +7,10 @@
   <!-- Basic properties -->
   <property
       i18n:translate=""
-      name="title">Curing Methods</property>
+      name="title">Curing Method</property>
   <property
       i18n:translate=""
-      name="description">Curing Methods</property>
+      name="description">Curing Method</property>
 
   <property name="allow_discussion">False</property>
   <property name="factory">CuringMethod</property>
@@ -22,10 +22,10 @@
   <property name="filter_content_types">True</property>
   <!-- Schema, class and security -->
   <property name="add_permission">cmf.AddPortalContent</property>
-  <property name="klass">bika.cement.content.curingmethod.CuringMethod</property>
   <property name="model_file"></property>
   <property name="model_source"></property>
-  <property name="schema">bika.cement.content.curingmethod.ICuringMethod</property>
+  <property name="schema">bika.cement.content.curingmethod.ICuringMethodSchema</property>
+  <property name="klass">bika.cement.content.curingmethod.CuringMethod</property>
 
   <!-- Enabled behaviors -->
   <property name="behaviors" purge="false">

--- a/src/bika/cement/profiles/default/types/CuringMethods.xml
+++ b/src/bika/cement/profiles/default/types/CuringMethods.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<object name="CuringMethodFolder" meta_type="Dexterity FTI"
+<object name="CuringMethods" meta_type="Dexterity FTI"
         i18n:domain="bika.cement"
         xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
@@ -13,10 +13,10 @@
   <property name="icon_expr">senaite_theme/icon/container</property>
 
   <!-- factory name; usually the same as type name -->
-  <property name="factory">CuringMethodFolder</property>
+  <property name="factory">CuringMethods</property>
 
   <!-- URL TALES expression to add an item TTW -->
-  <property name="add_view_expr">string:${folder_url}/++add++CuringMethodFolder</property>
+  <property name="add_view_expr">string:${folder_url}/++add++CuringMethods</property>
 
   <property name="link_target"/>
   <property name="immediate_view">view</property>
@@ -45,8 +45,8 @@
   <property name="add_permission">cmf.AddPortalContent</property>
 
   <!-- Python class for content items of this sort -->
-  <property name="schema">bika.cement.content.curingmethodfolder.ICuringMethodFolder</property>
-  <property name="klass">bika.cement.content.curingmethodfolder.CuringMethodFolder</property>
+  <property name="schema">bika.cement.content.curingmethods.ICuringMethodsSchema</property>
+  <property name="klass">bika.cement.content.curingmethods.CuringMethods</property>
 
   <!-- Dexterity behaviours for this type -->
   <property name="behaviors">

--- a/src/bika/cement/setuphandlers.py
+++ b/src/bika/cement/setuphandlers.py
@@ -55,11 +55,11 @@ def add_dexterity_setup_items(portal):
     items = [
         ("materialtype_folder", "Material Types", "MaterialTypeFolder"),
         ("materialclass_folder", "Material Classes", "MaterialClassFolder"),
-        ("curingmethod_folder", "Curing Methods", "CuringMethodFolder"),
+        ("curingmethods", "Curing Methods", "CuringMethods"),
         ("mixtype_folder", "Mix Types", "MixTypeFolder"),
         ("mixmaterial_folder", "Mix Materials", "MixMaterialFolder"),
     ]
-    setup = api.get_setup()
+    setup = api.get_senaite_setup()
     add_dexterity_items(setup, items)
 
 


### PR DESCRIPTION
-Add curing methods to senaite setup instead of bika setup

## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1061

## Current behavior before PR

- Incorrectly added folder at the end of the curing method folder name
- curing methods were being added to bika_setup instead of senaite_setup where dexterity objects reside

## Desired behavior after PR is merged

- Rename CuringMethodFolder to CuringMethods
- Add curing methods to senaite setup instead of bika setup

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
