### PR TITLE
Rename mix material and material class folders

### DIFF
--- a/src/bika/cement/browser/controlpanel/configure.zcml
+++ b/src/bika/cement/browser/controlpanel/configure.zcml
@@ -23,9 +23,9 @@
 
   <!-- Material Class Folder -->
   <browser:page
-      for="bika.cement.content.materialclassfolder.IMaterialClassFolder"
+      for="bika.cement.content.materialclasses.IMaterialClasses"
       name="view"
-      class=".materialclassfolder.MaterialClassFolderView"
+      class=".materialclasses.MaterialClassesView"
       permission="senaite.core.permissions.ManageBika"
       layer="bika.cement.interfaces.IBikaCementLayer"/>
 
@@ -39,9 +39,9 @@
 
   <!-- Mix Material Folder -->
   <browser:page
-      for="bika.cement.content.mixmaterialfolder.IMixMaterialFolder"
+      for="bika.cement.content.mixmaterials.IMixMaterials"
       name="view"
-      class=".mixmaterialfolder.MixMaterialFolderView"
+      class=".mixmaterials.MixMaterialsView"
       permission="senaite.core.permissions.ManageBika"
       layer="bika.cement.interfaces.IBikaCementLayer"/>
 

--- a/src/bika/cement/browser/controlpanel/materialclasses.py
+++ b/src/bika/cement/browser/controlpanel/materialclasses.py
@@ -22,60 +22,48 @@ import collections
 
 from bika.cement.config import _
 from bika.lims import api
-from bika.lims.utils import get_link, get_link_for
+from bika.lims.utils import get_link_for
 from senaite.app.listing import ListingView
 from senaite.core.catalog import SETUP_CATALOG
 
 
-class MixMaterialFolderView(ListingView):
+class MaterialClassesView(ListingView):
     """Displays all available sample containers in a table
     """
 
     def __init__(self, context, request):
-        super(MixMaterialFolderView, self).__init__(context, request)
-
+        super(MaterialClassesView, self).__init__(context, request)
         self.catalog = SETUP_CATALOG
 
         self.contentFilter = {
-            "portal_type": "MixMaterial",
-            "sort_on": "sortable_title",
+            "portal_type": "MaterialClass",
+            "sort_on": "sort_key",
+            "sort_order": "ascending",
         }
 
         self.context_actions = {
             _("Add"): {
-                "url": "++add++MixMaterial",
+                "url": "++add++MaterialClass",
                 "icon": "++resource++bika.lims.images/add.png",
             }}
 
         t = self.context.translate
-        self.title = t(_("Mix Materials"))
+        self.title = t(_("Material Classes"))
         self.description = t(_(""))
 
         self.show_select_column = True
         self.pagesize = 25
 
         self.columns = collections.OrderedDict((
+            ("sort_key", {
+                "title": _("Sort Key"),
+                "index": "sort_key"}),
             ("title", {
                 "title": _("Title"),
-                "index": "sortable_title"}),
-            ("material_type", {
-                "title": _("Material Type"),
-                "index": "material_type"}),
-            ("manufacturer", {
-                "title": _("Manufacturer"),
-                "index": "sortable_title"}),
-            ("supplier", {
-                "title": _("Supplier"),
                 "index": "sortable_title"}),
             ("description", {
                 "title": _("Description"),
                 "index": "description"}),
-            ("specific_gravity", {
-                "title": _("Specific Gravity"),
-                "index": "specific_gravity"}),
-            ("absorption_rate", {
-                "title": _("Absorption Rate"),
-                "index": "absorption_rate"}),
         ))
 
         self.review_states = [
@@ -110,43 +98,6 @@ class MixMaterialFolderView(ListingView):
 
         item["replace"]["title"] = get_link_for(obj)
         item["description"] = api.get_description(obj)
-        item["specific_gravity"] = obj.specific_gravity
-        item["absorption_rate"] = obj.absorption_rate
-
-        # Manufacturer
-        manufacturer_list = obj.manufacturer
-        if manufacturer_list:
-            manufacturer_obj = api.get_object_by_uid(manufacturer_list[0])
-            manufacturer_title = manufacturer_obj.title
-            manufacturer_url = manufacturer_obj.absolute_url()
-            manufacturer_link = get_link(
-                manufacturer_url, manufacturer_title
-            )
-            item["manufacturer"] = manufacturer_title
-            item["replace"]["manufacturer"] = manufacturer_link
-
-        # Supplier
-        supplier_list = obj.supplier
-        if supplier_list:
-            supplier_obj = api.get_object_by_uid(supplier_list[0])
-            supplier_title = supplier_obj.title
-            supplier_url = supplier_obj.absolute_url()
-            supplier_link = get_link(
-                supplier_url, supplier_title
-            )
-            item["supplier"] = supplier_title
-            item["replace"]["supplier"] = supplier_link
-
-        # Material Type
-        material_type_list = obj.material_type
-        if material_type_list:
-            material_type_obj = api.get_object_by_uid(material_type_list[0])
-            material_type_title = material_type_obj.title
-            material_type_url = material_type_obj.absolute_url()
-            material_type_link = get_link(
-                material_type_url, material_type_title
-            )
-            item["material_type"] = material_type_title
-            item["replace"]["material_type"] = material_type_link
+        item["sort_key"] = obj.sort_key
 
         return item

--- a/src/bika/cement/browser/controlpanel/mixmaterials.py
+++ b/src/bika/cement/browser/controlpanel/mixmaterials.py
@@ -22,48 +22,60 @@ import collections
 
 from bika.cement.config import _
 from bika.lims import api
-from bika.lims.utils import get_link_for
+from bika.lims.utils import get_link, get_link_for
 from senaite.app.listing import ListingView
 from senaite.core.catalog import SETUP_CATALOG
 
 
-class MaterialClassFolderView(ListingView):
+class MixMaterialsView(ListingView):
     """Displays all available sample containers in a table
     """
 
     def __init__(self, context, request):
-        super(MaterialClassFolderView, self).__init__(context, request)
+        super(MixMaterialsView, self).__init__(context, request)
+
         self.catalog = SETUP_CATALOG
 
         self.contentFilter = {
-            "portal_type": "MaterialClass",
-            "sort_on": "sort_key",
-            "sort_order": "ascending",
+            "portal_type": "MixMaterial",
+            "sort_on": "sortable_title",
         }
 
         self.context_actions = {
             _("Add"): {
-                "url": "++add++MaterialClass",
+                "url": "++add++MixMaterial",
                 "icon": "++resource++bika.lims.images/add.png",
             }}
 
         t = self.context.translate
-        self.title = t(_("Material Classes"))
+        self.title = t(_("Mix Materials"))
         self.description = t(_(""))
 
         self.show_select_column = True
         self.pagesize = 25
 
         self.columns = collections.OrderedDict((
-            ("sort_key", {
-                "title": _("Sort Key"),
-                "index": "sort_key"}),
             ("title", {
                 "title": _("Title"),
+                "index": "sortable_title"}),
+            ("material_type", {
+                "title": _("Material Type"),
+                "index": "material_type"}),
+            ("manufacturer", {
+                "title": _("Manufacturer"),
+                "index": "sortable_title"}),
+            ("supplier", {
+                "title": _("Supplier"),
                 "index": "sortable_title"}),
             ("description", {
                 "title": _("Description"),
                 "index": "description"}),
+            ("specific_gravity", {
+                "title": _("Specific Gravity"),
+                "index": "specific_gravity"}),
+            ("absorption_rate", {
+                "title": _("Absorption Rate"),
+                "index": "absorption_rate"}),
         ))
 
         self.review_states = [
@@ -98,6 +110,43 @@ class MaterialClassFolderView(ListingView):
 
         item["replace"]["title"] = get_link_for(obj)
         item["description"] = api.get_description(obj)
-        item["sort_key"] = obj.sort_key
+        item["specific_gravity"] = obj.specific_gravity
+        item["absorption_rate"] = obj.absorption_rate
+
+        # Manufacturer
+        manufacturer_list = obj.manufacturer
+        if manufacturer_list:
+            manufacturer_obj = api.get_object_by_uid(manufacturer_list[0])
+            manufacturer_title = manufacturer_obj.title
+            manufacturer_url = manufacturer_obj.absolute_url()
+            manufacturer_link = get_link(
+                manufacturer_url, manufacturer_title
+            )
+            item["manufacturer"] = manufacturer_title
+            item["replace"]["manufacturer"] = manufacturer_link
+
+        # Supplier
+        supplier_list = obj.supplier
+        if supplier_list:
+            supplier_obj = api.get_object_by_uid(supplier_list[0])
+            supplier_title = supplier_obj.title
+            supplier_url = supplier_obj.absolute_url()
+            supplier_link = get_link(
+                supplier_url, supplier_title
+            )
+            item["supplier"] = supplier_title
+            item["replace"]["supplier"] = supplier_link
+
+        # Material Type
+        material_type_list = obj.material_type
+        if material_type_list:
+            material_type_obj = api.get_object_by_uid(material_type_list[0])
+            material_type_title = material_type_obj.title
+            material_type_url = material_type_obj.absolute_url()
+            material_type_link = get_link(
+                material_type_url, material_type_title
+            )
+            item["material_type"] = material_type_title
+            item["replace"]["material_type"] = material_type_link
 
         return item

--- a/src/bika/cement/content/materialclass.py
+++ b/src/bika/cement/content/materialclass.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from AccessControl import ClassSecurityInfo
+from bika.cement.interfaces import IMaterialClass
 from bika.lims.interfaces import IDeactivable
 from plone.dexterity.content import Container
 from plone.supermodel import model
@@ -10,7 +11,7 @@ from zope.interface import implementer
 from zope import schema
 
 
-class IMaterialClass(model.Schema):
+class IMaterialClassSchema(model.Schema):
     """Marker interface and Dexterity Python Schema for MaterialClass"""
 
     title = schema.TextLine(
@@ -29,7 +30,7 @@ class IMaterialClass(model.Schema):
     )
 
 
-@implementer(IMaterialClass, IDeactivable)
+@implementer(IMaterialClass, IMaterialClassSchema, IDeactivable)
 class MaterialClass(Container):
     """Content-type class for IMaterialClass"""
 

--- a/src/bika/cement/content/materialclasses.py
+++ b/src/bika/cement/content/materialclasses.py
@@ -22,18 +22,18 @@ from plone.dexterity.content import Container
 from plone.supermodel import model
 from zope.interface import implementer
 
-from bika.cement.interfaces import IMaterialClassFolder
+from bika.cement.interfaces import IMaterialClasses
 from senaite.core.interfaces import IHideActionsMenu
 
 
-class IMaterialClassFolderSchema(model.Schema):
+class IMaterialClassesSchema(model.Schema):
     """Schema interface
     """
 
 
-@implementer(IMaterialClassFolder,
-             IMaterialClassFolderSchema,
+@implementer(IMaterialClasses,
+             IMaterialClassesSchema,
              IHideActionsMenu)
-class MaterialClassFolder(Container):
+class MaterialClasses(Container):
     """A folder/container for material classes
     """

--- a/src/bika/cement/content/mixmaterial.py
+++ b/src/bika/cement/content/mixmaterial.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from AccessControl import ClassSecurityInfo
+from bika.cement.interfaces import IMixMaterial
 from bika.lims.interfaces import IDeactivable
 from plone.dexterity.content import Container
 from plone.supermodel import model
@@ -12,7 +13,7 @@ from zope import schema
 from senaite.core.schema import UIDReferenceField
 
 
-class IMixMaterial(model.Schema):
+class IMixMaterialSchema(model.Schema):
     """Marker interface and Dexterity Python Schema for Mix Material"""
 
     # add basic things here
@@ -58,7 +59,7 @@ class IMixMaterial(model.Schema):
     )
 
 
-@implementer(IMixMaterial, IDeactivable)
+@implementer(IMixMaterial, IMixMaterialSchema, IDeactivable)
 class MixMaterial(Container):
     """Content-type class for IMixMaterial"""
 

--- a/src/bika/cement/content/mixmaterials.py
+++ b/src/bika/cement/content/mixmaterials.py
@@ -22,16 +22,16 @@ from plone.dexterity.content import Container
 from plone.supermodel import model
 from zope.interface import implementer
 
-from bika.cement.interfaces import IMixMaterialFolder
+from bika.cement.interfaces import IMixMaterials
 from senaite.core.interfaces import IHideActionsMenu
 
 
-class IMixMaterialFolderSchema(model.Schema):
+class IMixMaterialsSchema(model.Schema):
     """Schema interface
     """
 
 
-@implementer(IMixMaterialFolder, IMixMaterialFolderSchema, IHideActionsMenu)
-class MixMaterialFolder(Container):
+@implementer(IMixMaterials, IMixMaterialsSchema, IHideActionsMenu)
+class MixMaterials(Container):
     """A folder/container for material types
     """

--- a/src/bika/cement/interfaces.py
+++ b/src/bika/cement/interfaces.py
@@ -15,7 +15,12 @@ class IMaterialTypeFolder(Interface):
     """
 
 
-class IMaterialClassFolder(Interface):
+class IMaterialClass(Interface):
+    """Marker interface for material classes
+    """
+
+
+class IMaterialClasses(Interface):
     """Marker interface for material classes setup folder
     """
 
@@ -35,6 +40,11 @@ class IMixTypeFolder(Interface):
     """
 
 
-class IMixMaterialFolder(Interface):
-    """Marker interface for mix type setup folder
+class IMixMaterial(Interface):
+    """Marker interface for mix material
+    """
+
+
+class IMixMaterials(Interface):
+    """Marker interface for mix material setup folder
     """

--- a/src/bika/cement/profiles/default/types.xml
+++ b/src/bika/cement/profiles/default/types.xml
@@ -8,7 +8,7 @@
 
   <!-- Material Classes -->
   <object name="MaterialClass" meta_type="Dexterity FTI"/>
-  <object name="MaterialClassFolder" meta_type="Dexterity FTI"/>
+  <object name="MaterialClasses" meta_type="Dexterity FTI"/>
 
   <!-- Curing Methods -->
   <object name="CuringMethod" meta_type="Dexterity FTI" />
@@ -20,7 +20,7 @@
 
   <!-- Mix Materials -->
   <object name="MixMaterial" meta_type="Dexterity FTI" />
-  <object name="MixMaterialFolder" meta_type="Dexterity FTI" />
+  <object name="MixMaterials" meta_type="Dexterity FTI" />
 
 </object>
 

--- a/src/bika/cement/profiles/default/types/MaterialClass.xml
+++ b/src/bika/cement/profiles/default/types/MaterialClass.xml
@@ -24,7 +24,7 @@
   <property name="add_permission">cmf.AddPortalContent</property>
   <property name="model_file"></property>
   <property name="model_source"></property>
-  <property name="schema">bika.cement.content.materialclass.IMaterialClass</property>
+  <property name="schema">bika.cement.content.materialclass.IMaterialClassSchema</property>
   <property name="klass">bika.cement.content.materialclass.MaterialClass</property>
 
   <!-- Enabled behaviors -->

--- a/src/bika/cement/profiles/default/types/MaterialClasses.xml
+++ b/src/bika/cement/profiles/default/types/MaterialClasses.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<object name="MixMaterialFolder" meta_type="Dexterity FTI"
+<object name="MaterialClasses" meta_type="Dexterity FTI"
         i18n:domain="bika.cement"
         xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <!-- Title and Description -->
   <property name="title"
-            i18n:translate="">Mix Material</property>
+            i18n:translate="">Material Classes</property>
   <property name="description"
             i18n:translate=""></property>
 
@@ -13,10 +13,10 @@
   <property name="icon_expr">senaite_theme/icon/container</property>
 
   <!-- factory name; usually the same as type name -->
-  <property name="factory">MixMaterialFolder</property>
+  <property name="factory">MaterialClasses</property>
 
   <!-- URL TALES expression to add an item TTW -->
-  <property name="add_view_expr">string:${folder_url}/++add++MixMaterialFolder</property>
+  <property name="add_view_expr">string:${folder_url}/++add++MaterialClasses</property>
 
   <property name="link_target"/>
   <property name="immediate_view">view</property>
@@ -28,7 +28,7 @@
   <property name="filter_content_types">True</property>
   <!-- If filtering, what's allowed -->
   <property name="allowed_content_types">
-    <element value="MixMaterial" />
+    <element value="MaterialClass" />
   </property>
 
   <property name="allow_discussion">False</property>
@@ -45,8 +45,8 @@
   <property name="add_permission">cmf.AddPortalContent</property>
 
   <!-- Python class for content items of this sort -->
-  <property name="schema">bika.cement.content.mixmaterialfolder.IMixMaterialFolder</property>
-  <property name="klass">bika.cement.content.mixmaterialfolder.MixMaterialFolder</property>
+  <property name="schema">bika.cement.content.materialclassfolder.IMaterialClassesSchema</property>
+  <property name="klass">bika.cement.content.materialclassfolder.MaterialClasses</property>
 
   <!-- Dexterity behaviours for this type -->
   <property name="behaviors">

--- a/src/bika/cement/profiles/default/types/MaterialClasses.xml
+++ b/src/bika/cement/profiles/default/types/MaterialClasses.xml
@@ -45,8 +45,8 @@
   <property name="add_permission">cmf.AddPortalContent</property>
 
   <!-- Python class for content items of this sort -->
-  <property name="schema">bika.cement.content.materialclassfolder.IMaterialClassesSchema</property>
-  <property name="klass">bika.cement.content.materialclassfolder.MaterialClasses</property>
+  <property name="schema">bika.cement.content.materialclasses.IMaterialClassesSchema</property>
+  <property name="klass">bika.cement.content.materialclasses.MaterialClasses</property>
 
   <!-- Dexterity behaviours for this type -->
   <property name="behaviors">

--- a/src/bika/cement/profiles/default/types/MixMaterial.xml
+++ b/src/bika/cement/profiles/default/types/MixMaterial.xml
@@ -22,10 +22,11 @@
   <property name="filter_content_types">True</property>
   <!-- Schema, class and security -->
   <property name="add_permission">cmf.AddPortalContent</property>
-  <property name="klass">bika.cement.content.mixmaterial.MixMaterial</property>
   <property name="model_file"></property>
   <property name="model_source"></property>
-  <property name="schema">bika.cement.content.mixmaterial.IMixMaterial</property>
+  <property name="schema">bika.cement.content.mixmaterial.IMixMaterialSchema</property>
+  <property name="klass">bika.cement.content.mixmaterial.MixMaterial</property>
+
 
   <!-- Enabled behaviors -->
   <property name="behaviors" purge="false">

--- a/src/bika/cement/profiles/default/types/MixMaterials.xml
+++ b/src/bika/cement/profiles/default/types/MixMaterials.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<object name="MaterialClassFolder" meta_type="Dexterity FTI"
+<object name="MixMaterials" meta_type="Dexterity FTI"
         i18n:domain="bika.cement"
         xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <!-- Title and Description -->
   <property name="title"
-            i18n:translate="">Material Classes</property>
+            i18n:translate="">Mix Material</property>
   <property name="description"
             i18n:translate=""></property>
 
@@ -13,10 +13,10 @@
   <property name="icon_expr">senaite_theme/icon/container</property>
 
   <!-- factory name; usually the same as type name -->
-  <property name="factory">MaterialClassFolder</property>
+  <property name="factory">MixMaterials</property>
 
   <!-- URL TALES expression to add an item TTW -->
-  <property name="add_view_expr">string:${folder_url}/++add++MaterialClassFolder</property>
+  <property name="add_view_expr">string:${folder_url}/++add++MixMaterials</property>
 
   <property name="link_target"/>
   <property name="immediate_view">view</property>
@@ -28,7 +28,7 @@
   <property name="filter_content_types">True</property>
   <!-- If filtering, what's allowed -->
   <property name="allowed_content_types">
-    <element value="MaterialClass" />
+    <element value="MixMaterial" />
   </property>
 
   <property name="allow_discussion">False</property>
@@ -45,8 +45,8 @@
   <property name="add_permission">cmf.AddPortalContent</property>
 
   <!-- Python class for content items of this sort -->
-  <property name="schema">bika.cement.content.materialclassfolder.IMaterialClassFolder</property>
-  <property name="klass">bika.cement.content.materialclassfolder.MaterialClassFolder</property>
+  <property name="schema">bika.cement.content.mixmaterialfolder.IMixMaterialsSchema</property>
+  <property name="klass">bika.cement.content.mixmaterialfolder.MixMaterials</property>
 
   <!-- Dexterity behaviours for this type -->
   <property name="behaviors">

--- a/src/bika/cement/profiles/default/types/MixMaterials.xml
+++ b/src/bika/cement/profiles/default/types/MixMaterials.xml
@@ -45,8 +45,8 @@
   <property name="add_permission">cmf.AddPortalContent</property>
 
   <!-- Python class for content items of this sort -->
-  <property name="schema">bika.cement.content.mixmaterialfolder.IMixMaterialsSchema</property>
-  <property name="klass">bika.cement.content.mixmaterialfolder.MixMaterials</property>
+  <property name="schema">bika.cement.content.mixmaterials.IMixMaterialsSchema</property>
+  <property name="klass">bika.cement.content.mixmaterials.MixMaterials</property>
 
   <!-- Dexterity behaviours for this type -->
   <property name="behaviors">

--- a/src/bika/cement/setuphandlers.py
+++ b/src/bika/cement/setuphandlers.py
@@ -54,10 +54,10 @@ def add_dexterity_setup_items(portal):
     # Tuples of ID, Title, FTI
     items = [
         ("materialtype_folder", "Material Types", "MaterialTypeFolder"),
-        ("materialclass_folder", "Material Classes", "MaterialClassFolder"),
+        ("materialclasses", "Material Classes", "MaterialClasses"),
         ("curingmethods", "Curing Methods", "CuringMethods"),
         ("mixtype_folder", "Mix Types", "MixTypeFolder"),
-        ("mixmaterial_folder", "Mix Materials", "MixMaterialFolder"),
+        ("mixmaterials", "Mix Materials", "MixMaterials"),
     ]
     setup = api.get_senaite_setup()
     add_dexterity_items(setup, items)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1056, https://bika.atlassian.net/browse/LIMS-1059

## Current behavior before PR

- Incorrectly added folder at the end of the mix material folder name
- Incorrectly added folder at the end of the material class folder name

## Desired behavior after PR is merged

- Rename MixMaterialFolder to MixMaterials
- Rename MaterialClassFolder to MaterialClasses

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
