### PR TITLE
Rename Material Types and Mix Types content types

### DIFF
--- a/src/bika/cement/browser/controlpanel/configure.zcml
+++ b/src/bika/cement/browser/controlpanel/configure.zcml
@@ -7,15 +7,15 @@
 
   <!-- Material Type Folder -->
   <browser:page
-      for="bika.cement.content.materialtypefolder.IMaterialTypeFolder"
+      for="bika.cement.interfaces.IMaterialTypes"
       name="view"
-      class=".materialtypefolder.MaterialTypeFolderView"
+      class=".materialtypes.MaterialTypesView"
       permission="senaite.core.permissions.ManageBika"
       layer="bika.cement.interfaces.IBikaCementLayer"/>
       
   <!-- Curing Method Folder -->
   <browser:page
-      for="bika.cement.content.curingmethods.ICuringMethods"
+      for="bika.cement.interfaces.ICuringMethods"
       name="view"
       class=".curingmethods.CuringMethodsView"
       permission="senaite.core.permissions.ManageBika"
@@ -23,7 +23,7 @@
 
   <!-- Material Class Folder -->
   <browser:page
-      for="bika.cement.content.materialclasses.IMaterialClasses"
+      for="bika.cement.interfaces.IMaterialClasses"
       name="view"
       class=".materialclasses.MaterialClassesView"
       permission="senaite.core.permissions.ManageBika"
@@ -31,15 +31,15 @@
 
   <!-- Mix Type Folder -->
   <browser:page
-      for="bika.cement.content.mixtypefolder.IMixTypeFolder"
+      for="bika.cement.interfaces.IMixTypes"
       name="view"
-      class=".mixtypefolder.MixTypeFolderView"
+      class=".mixtypes.MixTypesView"
       permission="senaite.core.permissions.ManageBika"
       layer="bika.cement.interfaces.IBikaCementLayer"/>
 
   <!-- Mix Material Folder -->
   <browser:page
-      for="bika.cement.content.mixmaterials.IMixMaterials"
+      for="bika.cement.interfaces.IMixMaterials"
       name="view"
       class=".mixmaterials.MixMaterialsView"
       permission="senaite.core.permissions.ManageBika"

--- a/src/bika/cement/browser/controlpanel/materialtypes.py
+++ b/src/bika/cement/browser/controlpanel/materialtypes.py
@@ -22,46 +22,51 @@ import collections
 
 from bika.cement.config import _
 from bika.lims import api
-from bika.lims.utils import get_link_for
+from bika.lims.utils import get_link, get_link_for
 from senaite.app.listing import ListingView
 from senaite.core.catalog import SETUP_CATALOG
 
 
-class MixTypeFolderView(ListingView):
-    """Displays all available sample containers in a table
-    """
+class MaterialTypesView(ListingView):
+    """Displays all available material types in a table"""
 
     def __init__(self, context, request):
-        super(MixTypeFolderView, self).__init__(context, request)
+        super(MaterialTypesView, self).__init__(context, request)
 
         self.catalog = SETUP_CATALOG
 
         self.contentFilter = {
-            "portal_type": "MixType",
+            "portal_type": "MaterialType",
             "sort_on": "sortable_title",
         }
 
         self.context_actions = {
             _("Add"): {
-                "url": "++add++MixType",
+                "url": "++add++MaterialType",
                 "icon": "++resource++bika.lims.images/add.png",
-            }}
+            }
+        }
 
         t = self.context.translate
-        self.title = t(_("Mix Types"))
+        self.title = t(_("Material Types"))
         self.description = t(_(""))
 
         self.show_select_column = True
         self.pagesize = 25
 
-        self.columns = collections.OrderedDict((
-            ("title", {
-                "title": _("Title"),
-                "index": "sortable_title"}),
-            ("description", {
-                "title": _("Description"),
-                "index": "description"}),
-        ))
+        self.columns = collections.OrderedDict(
+            (
+                ("title", {"title": _("Title"), "index": "sortable_title"}),
+                (
+                    "material_class",
+                    {"title": _("Material Class"), "index": "sortable_title"},
+                ),
+                (
+                    "description",
+                    {"title": _("Description"), "index": "description"},
+                ),
+            )
+        )
 
         self.review_states = [
             {
@@ -69,12 +74,14 @@ class MixTypeFolderView(ListingView):
                 "title": _("Active"),
                 "contentFilter": {"is_active": True},
                 "columns": self.columns.keys(),
-            }, {
+            },
+            {
                 "id": "inactive",
                 "title": _("Inactive"),
-                "contentFilter": {'is_active': False},
+                "contentFilter": {"is_active": False},
                 "columns": self.columns.keys(),
-            }, {
+            },
+            {
                 "id": "all",
                 "title": _("All"),
                 "contentFilter": {},
@@ -96,4 +103,14 @@ class MixTypeFolderView(ListingView):
         item["replace"]["title"] = get_link_for(obj)
         item["description"] = api.get_description(obj)
 
+        material_class_list = obj.material_class
+        if material_class_list:
+            material_class_obj = api.get_object_by_uid(material_class_list[0])
+            material_class_title = material_class_obj.title
+            material_class_url = material_class_obj.absolute_url()
+            material_class_link = get_link(
+                material_class_url, material_class_title
+            )
+            item["material_class"] = material_class_title
+            item["replace"]["material_class"] = material_class_link
         return item

--- a/src/bika/cement/browser/controlpanel/mixtypes.py
+++ b/src/bika/cement/browser/controlpanel/mixtypes.py
@@ -22,51 +22,46 @@ import collections
 
 from bika.cement.config import _
 from bika.lims import api
-from bika.lims.utils import get_link, get_link_for
+from bika.lims.utils import get_link_for
 from senaite.app.listing import ListingView
 from senaite.core.catalog import SETUP_CATALOG
 
 
-class MaterialTypeFolderView(ListingView):
-    """Displays all available sample containers in a table"""
+class MixTypesView(ListingView):
+    """Displays all available sample containers in a table
+    """
 
     def __init__(self, context, request):
-        super(MaterialTypeFolderView, self).__init__(context, request)
+        super(MixTypesView, self).__init__(context, request)
 
         self.catalog = SETUP_CATALOG
 
         self.contentFilter = {
-            "portal_type": "MaterialType",
+            "portal_type": "MixType",
             "sort_on": "sortable_title",
         }
 
         self.context_actions = {
             _("Add"): {
-                "url": "++add++MaterialType",
+                "url": "++add++MixType",
                 "icon": "++resource++bika.lims.images/add.png",
-            }
-        }
+            }}
 
         t = self.context.translate
-        self.title = t(_("Material Types"))
+        self.title = t(_("Mix Types"))
         self.description = t(_(""))
 
         self.show_select_column = True
         self.pagesize = 25
 
-        self.columns = collections.OrderedDict(
-            (
-                ("title", {"title": _("Title"), "index": "sortable_title"}),
-                (
-                    "MaterialClass",
-                    {"title": _("Material Class"), "index": "sortable_title"},
-                ),
-                (
-                    "description",
-                    {"title": _("Description"), "index": "description"},
-                ),
-            )
-        )
+        self.columns = collections.OrderedDict((
+            ("title", {
+                "title": _("Title"),
+                "index": "sortable_title"}),
+            ("description", {
+                "title": _("Description"),
+                "index": "description"}),
+        ))
 
         self.review_states = [
             {
@@ -74,14 +69,12 @@ class MaterialTypeFolderView(ListingView):
                 "title": _("Active"),
                 "contentFilter": {"is_active": True},
                 "columns": self.columns.keys(),
-            },
-            {
+            }, {
                 "id": "inactive",
                 "title": _("Inactive"),
-                "contentFilter": {"is_active": False},
+                "contentFilter": {'is_active': False},
                 "columns": self.columns.keys(),
-            },
-            {
+            }, {
                 "id": "all",
                 "title": _("All"),
                 "contentFilter": {},
@@ -103,14 +96,4 @@ class MaterialTypeFolderView(ListingView):
         item["replace"]["title"] = get_link_for(obj)
         item["description"] = api.get_description(obj)
 
-        material_class_list = obj.MaterialClass
-        if material_class_list:
-            material_class_obj = api.get_object_by_uid(material_class_list[0])
-            material_class_title = material_class_obj.title
-            material_class_url = material_class_obj.absolute_url()
-            material_class_link = get_link(
-                material_class_url, material_class_title
-            )
-            item["MaterialClass"] = material_class_title
-            item["replace"]["MaterialClass"] = material_class_link
         return item

--- a/src/bika/cement/content/curingmethod.py
+++ b/src/bika/cement/content/curingmethod.py
@@ -16,7 +16,7 @@ class ICuringMethodSchema(model.Schema):
 
     title = schema.TextLine(
         title=u"Title",
-        required=False,
+        required=True,
     )
 
     description = schema.Text(

--- a/src/bika/cement/content/materialtype.py
+++ b/src/bika/cement/content/materialtype.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from AccessControl import ClassSecurityInfo
+from bika.cement.interfaces import IMaterialType
 from bika.lims.interfaces import IDeactivable
 from plone.dexterity.content import Container
 from plone.supermodel import model
@@ -11,7 +12,7 @@ from zope import schema
 from zope.interface import implementer
 
 
-class IMaterialType(model.Schema):
+class IMaterialTypeSchema(model.Schema):
     """Marker interface and Dexterity Python Schema for Material Types"""
 
     title = schema.TextLine(
@@ -24,7 +25,7 @@ class IMaterialType(model.Schema):
         required=False,
     )
 
-    MaterialClass = UIDReferenceField(
+    material_class = UIDReferenceField(
         title=u"Material Class",
         allowed_types=("MaterialClass", ),
         multi_valued=False,
@@ -32,7 +33,7 @@ class IMaterialType(model.Schema):
     )
 
 
-@implementer(IMaterialType, IDeactivable)
+@implementer(IMaterialType, IMaterialTypeSchema, IDeactivable)
 class MaterialType(Container):
     """Content-type class for IMaterialType"""
 

--- a/src/bika/cement/content/materialtypes.py
+++ b/src/bika/cement/content/materialtypes.py
@@ -22,16 +22,16 @@ from plone.dexterity.content import Container
 from plone.supermodel import model
 from zope.interface import implementer
 
-from bika.cement.interfaces import IMixTypeFolder
+from bika.cement.interfaces import IMaterialTypes
 from senaite.core.interfaces import IHideActionsMenu
 
 
-class IMixTypeFolderSchema(model.Schema):
+class IMaterialTypesSchema(model.Schema):
     """Schema interface
     """
 
 
-@implementer(IMixTypeFolder, IMixTypeFolderSchema, IHideActionsMenu)
-class MixTypeFolder(Container):
+@implementer(IMaterialTypes, IMaterialTypesSchema, IHideActionsMenu)
+class MaterialTypes(Container):
     """A folder/container for material types
     """

--- a/src/bika/cement/content/mixtype.py
+++ b/src/bika/cement/content/mixtype.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from AccessControl import ClassSecurityInfo
+from bika.cement.interfaces import IMixType
 from bika.lims.interfaces import IDeactivable
 from plone.dexterity.content import Container
 from plone.supermodel import model
@@ -10,8 +11,8 @@ from zope import schema
 from zope.interface import implementer
 
 
-class IMixType(model.Schema):
-    """Marker interface and Dexterity Python Schema for Curing Methods"""
+class IMixTypeSchema(model.Schema):
+    """Marker interface and Dexterity Python Schema for Mix Types"""
 
     title = schema.TextLine(
         title=u"Title",
@@ -24,7 +25,7 @@ class IMixType(model.Schema):
     )
 
 
-@implementer(IMixType, IDeactivable)
+@implementer(IMixType, IMixTypeSchema, IDeactivable)
 class MixType(Container):
     """Content-type class for IMixType"""
 

--- a/src/bika/cement/content/mixtype.py
+++ b/src/bika/cement/content/mixtype.py
@@ -16,7 +16,7 @@ class IMixTypeSchema(model.Schema):
 
     title = schema.TextLine(
         title=u"Title",
-        required=False,
+        required=True,
     )
 
     description = schema.Text(

--- a/src/bika/cement/content/mixtypes.py
+++ b/src/bika/cement/content/mixtypes.py
@@ -22,16 +22,16 @@ from plone.dexterity.content import Container
 from plone.supermodel import model
 from zope.interface import implementer
 
-from bika.cement.interfaces import IMaterialTypeFolder
+from bika.cement.interfaces import IMixTypes
 from senaite.core.interfaces import IHideActionsMenu
 
 
-class IMaterialTypeFolderSchema(model.Schema):
+class IMixTypesSchema(model.Schema):
     """Schema interface
     """
 
 
-@implementer(IMaterialTypeFolder, IMaterialTypeFolderSchema, IHideActionsMenu)
-class MaterialTypeFolder(Container):
+@implementer(IMixTypes, IMixTypesSchema, IHideActionsMenu)
+class MixTypes(Container):
     """A folder/container for material types
     """

--- a/src/bika/cement/interfaces.py
+++ b/src/bika/cement/interfaces.py
@@ -10,7 +10,12 @@ class IBikaCementLayer(IDefaultBrowserLayer):
     """Marker interface that defines a browser layer."""
 
 
-class IMaterialTypeFolder(Interface):
+class IMaterialType(Interface):
+    """Marker interface for material types
+    """
+
+
+class IMaterialTypes(Interface):
     """Marker interface for material types setup folder
     """
 
@@ -35,16 +40,21 @@ class ICuringMethods(Interface):
     """
 
 
-class IMixTypeFolder(Interface):
+class IMixType(Interface):
+    """Marker interface for mix types
+    """
+
+
+class IMixTypes(Interface):
     """Marker interface for mix types setup folder
     """
 
 
 class IMixMaterial(Interface):
-    """Marker interface for mix material
+    """Marker interface for mix materials
     """
 
 
 class IMixMaterials(Interface):
-    """Marker interface for mix material setup folder
+    """Marker interface for mix materials setup folder
     """

--- a/src/bika/cement/profiles/default/types.xml
+++ b/src/bika/cement/profiles/default/types.xml
@@ -4,7 +4,7 @@
 
   <!-- Material Types -->
   <object name="MaterialType" meta_type="Dexterity FTI" />
-  <object name="MaterialTypeFolder" meta_type="Dexterity FTI" />
+  <object name="MaterialTypes" meta_type="Dexterity FTI" />
 
   <!-- Material Classes -->
   <object name="MaterialClass" meta_type="Dexterity FTI"/>
@@ -16,7 +16,7 @@
 
   <!-- Mix Types -->
   <object name="MixType" meta_type="Dexterity FTI" />
-  <object name="MixTypeFolder" meta_type="Dexterity FTI" />
+  <object name="MixTypes" meta_type="Dexterity FTI" />
 
   <!-- Mix Materials -->
   <object name="MixMaterial" meta_type="Dexterity FTI" />

--- a/src/bika/cement/profiles/default/types/MaterialType.xml
+++ b/src/bika/cement/profiles/default/types/MaterialType.xml
@@ -10,7 +10,7 @@
       name="title">Material Type</property>
   <property
       i18n:translate=""
-      name="description">Material Types</property>
+      name="description">Material Type</property>
 
   <property name="allow_discussion">False</property>
   <property name="factory">MaterialType</property>
@@ -22,10 +22,10 @@
   <property name="filter_content_types">True</property>
   <!-- Schema, class and security -->
   <property name="add_permission">cmf.AddPortalContent</property>
-  <property name="klass">bika.cement.content.materialtype.MaterialType</property>
   <property name="model_file"></property>
   <property name="model_source"></property>
-  <property name="schema">bika.cement.content.materialtype.IMaterialType</property>
+  <property name="schema">bika.cement.content.materialtype.IMaterialTypeSchema</property>
+  <property name="klass">bika.cement.content.materialtype.MaterialType</property>
 
   <!-- Enabled behaviors -->
   <property name="behaviors" purge="false">

--- a/src/bika/cement/profiles/default/types/MaterialTypes.xml
+++ b/src/bika/cement/profiles/default/types/MaterialTypes.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<object name="MixTypeFolder" meta_type="Dexterity FTI"
+<object name="MaterialTypes" meta_type="Dexterity FTI"
         i18n:domain="bika.cement"
         xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <!-- Title and Description -->
   <property name="title"
-            i18n:translate="">Mix Types</property>
+            i18n:translate="">Material Types</property>
   <property name="description"
             i18n:translate=""></property>
 
@@ -13,10 +13,10 @@
   <property name="icon_expr">senaite_theme/icon/container</property>
 
   <!-- factory name; usually the same as type name -->
-  <property name="factory">MixTypeFolder</property>
+  <property name="factory">MaterialTypes</property>
 
   <!-- URL TALES expression to add an item TTW -->
-  <property name="add_view_expr">string:${folder_url}/++add++MixTypeFolder</property>
+  <property name="add_view_expr">string:${folder_url}/++add++MaterialTypes</property>
 
   <property name="link_target"/>
   <property name="immediate_view">view</property>
@@ -28,7 +28,7 @@
   <property name="filter_content_types">True</property>
   <!-- If filtering, what's allowed -->
   <property name="allowed_content_types">
-    <element value="MixType" />
+    <element value="MaterialType" />
   </property>
 
   <property name="allow_discussion">False</property>
@@ -45,8 +45,8 @@
   <property name="add_permission">cmf.AddPortalContent</property>
 
   <!-- Python class for content items of this sort -->
-  <property name="schema">bika.cement.content.mixtypefolder.IMixTypeFolder</property>
-  <property name="klass">bika.cement.content.mixtypefolder.MixTypeFolder</property>
+  <property name="schema">bika.cement.content.materialtypes.IMaterialTypesSchema</property>
+  <property name="klass">bika.cement.content.materialtypes.MaterialTypes</property>
 
   <!-- Dexterity behaviours for this type -->
   <property name="behaviors">

--- a/src/bika/cement/profiles/default/types/MixType.xml
+++ b/src/bika/cement/profiles/default/types/MixType.xml
@@ -7,10 +7,10 @@
   <!-- Basic properties -->
   <property
       i18n:translate=""
-      name="title">Mix Types</property>
+      name="title">Mix Type</property>
   <property
       i18n:translate=""
-      name="description">Mix Types</property>
+      name="description">Mix Type</property>
 
   <property name="allow_discussion">False</property>
   <property name="factory">MixType</property>
@@ -22,10 +22,10 @@
   <property name="filter_content_types">True</property>
   <!-- Schema, class and security -->
   <property name="add_permission">cmf.AddPortalContent</property>
-  <property name="klass">bika.cement.content.mixtype.MixType</property>
   <property name="model_file"></property>
   <property name="model_source"></property>
-  <property name="schema">bika.cement.content.mixtype.IMixType</property>
+  <property name="schema">bika.cement.content.mixtype.IMixTypeSchema</property>
+  <property name="klass">bika.cement.content.mixtype.MixType</property>
 
   <!-- Enabled behaviors -->
   <property name="behaviors" purge="false">

--- a/src/bika/cement/profiles/default/types/MixTypes.xml
+++ b/src/bika/cement/profiles/default/types/MixTypes.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<object name="MaterialTypeFolder" meta_type="Dexterity FTI"
+<object name="MixTypes" meta_type="Dexterity FTI"
         i18n:domain="bika.cement"
         xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <!-- Title and Description -->
   <property name="title"
-            i18n:translate="">Material Types</property>
+            i18n:translate="">Mix Types</property>
   <property name="description"
             i18n:translate=""></property>
 
@@ -13,10 +13,10 @@
   <property name="icon_expr">senaite_theme/icon/container</property>
 
   <!-- factory name; usually the same as type name -->
-  <property name="factory">MaterialTypeFolder</property>
+  <property name="factory">MixTypes</property>
 
   <!-- URL TALES expression to add an item TTW -->
-  <property name="add_view_expr">string:${folder_url}/++add++MaterialTypeFolder</property>
+  <property name="add_view_expr">string:${folder_url}/++add++MixTypes</property>
 
   <property name="link_target"/>
   <property name="immediate_view">view</property>
@@ -28,7 +28,7 @@
   <property name="filter_content_types">True</property>
   <!-- If filtering, what's allowed -->
   <property name="allowed_content_types">
-    <element value="MaterialType" />
+    <element value="MixType" />
   </property>
 
   <property name="allow_discussion">False</property>
@@ -45,8 +45,8 @@
   <property name="add_permission">cmf.AddPortalContent</property>
 
   <!-- Python class for content items of this sort -->
-  <property name="schema">bika.cement.content.materialtypefolder.IMaterialTypeFolder</property>
-  <property name="klass">bika.cement.content.materialtypefolder.MaterialTypeFolder</property>
+  <property name="schema">bika.cement.content.mixtypes.IMixTypesSchema</property>
+  <property name="klass">bika.cement.content.mixtypes.MixTypes</property>
 
   <!-- Dexterity behaviours for this type -->
   <property name="behaviors">

--- a/src/bika/cement/setuphandlers.py
+++ b/src/bika/cement/setuphandlers.py
@@ -53,10 +53,10 @@ def add_dexterity_setup_items(portal):
     """
     # Tuples of ID, Title, FTI
     items = [
-        ("materialtype_folder", "Material Types", "MaterialTypeFolder"),
+        ("materialtypes", "Material Types", "MaterialTypes"),
         ("materialclasses", "Material Classes", "MaterialClasses"),
         ("curingmethods", "Curing Methods", "CuringMethods"),
-        ("mixtype_folder", "Mix Types", "MixTypeFolder"),
+        ("mixtypes", "Mix Types", "MixTypes"),
         ("mixmaterials", "Mix Materials", "MixMaterials"),
     ]
     setup = api.get_senaite_setup()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-

## Current behavior before PR

* Material and mix types are not named in a uniform manner
* There is a typo in the xml files
* The controlpanel config browser pages point to imports of the interfaces instead of the interface itself

## Desired behavior after PR is merged

* Rename Material Types and Mix Types content types
* Add Schema string to xml files
* Point directly to interfaces in the controlpanel config

--

I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
