### PR TITLE
Add tests for material types and mix types

### DIFF
--- a/src/bika/cement/tests/test_new_content_types.py
+++ b/src/bika/cement/tests/test_new_content_types.py
@@ -5,7 +5,9 @@
 # Copyright 2018 by it's authors.
 
 
-from bika.cement.content.curingmethods import ICuringMethods  # NOQA E501
+from bika.cement.content.curingmethods import ICuringMethods
+from bika.cement.content.materialtypes import IMaterialTypes
+from bika.cement.content.mixtypes import IMixTypes
 from bika.cement.tests.base import SimpleTestCase
 from plone import api
 from plone.app.testing import TEST_USER_ID
@@ -45,3 +47,47 @@ class TestContentTypes(SimpleTestCase):
         # check that deleting the object works too
         api.content.delete(obj=obj)
         self.assertNotIn('curingmethods', parent.objectIds())
+
+    def test_add_material_type(self):
+
+        obj = api.content.create(
+            container=self.portal,
+            type='MaterialTypes',
+            id='materialtypes',
+        )
+
+        self.assertTrue(
+            IMaterialTypes.providedBy(obj),
+            u'IMaterialTypes not provided by {0}!'.format(
+                obj.id,
+            ),
+        )
+
+        parent = obj.__parent__
+        self.assertIn('materialtypes', parent.objectIds())
+
+        # check that deleting the object works too
+        api.content.delete(obj=obj)
+        self.assertNotIn('materialtypes', parent.objectIds())
+
+    def test_add_mix_types(self):
+
+        obj = api.content.create(
+            container=self.portal,
+            type='MixTypes',
+            id='mixtypes',
+        )
+
+        self.assertTrue(
+            IMixTypes.providedBy(obj),
+            u'IMixTypes not provided by {0}!'.format(
+                obj.id,
+            ),
+        )
+
+        parent = obj.__parent__
+        self.assertIn('mixtypes', parent.objectIds())
+
+        # check that deleting the object works too
+        api.content.delete(obj=obj)
+        self.assertNotIn('mixtypes', parent.objectIds())


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1058

## Current behavior before PR

No tests for Material Types and Mix Types

## Desired behavior after PR is merged

Tests for Material Types and Mix Types have been added.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
