### PR TITLE
Fix sort order on material types listing

### DIFF
--- a/src/bika/cement/browser/controlpanel/materialtypes.py
+++ b/src/bika/cement/browser/controlpanel/materialtypes.py
@@ -38,6 +38,7 @@ class MaterialTypesView(ListingView):
         self.contentFilter = {
             "portal_type": "MaterialType",
             "sort_on": "sortable_title",
+            "sort_order": "ascending",
         }
 
         self.context_actions = {
@@ -59,7 +60,7 @@ class MaterialTypesView(ListingView):
                 ("title", {"title": _("Title"), "index": "sortable_title"}),
                 (
                     "material_class",
-                    {"title": _("Material Class"), "index": "sortable_title"},
+                    {"title": _("Material Class")},
                 ),
                 (
                     "description",

--- a/src/bika/cement/content/materialtype.py
+++ b/src/bika/cement/content/materialtype.py
@@ -5,11 +5,13 @@ from bika.cement.interfaces import IMaterialType
 from bika.lims.interfaces import IDeactivable
 from plone.dexterity.content import Container
 from plone.supermodel import model
+from plone.autoform import directives
 from senaite.core.catalog import SETUP_CATALOG
-from bika.lims import api
 from senaite.core.schema import UIDReferenceField
+from bika.lims import api
 from zope import schema
 from zope.interface import implementer
+from senaite.core.z3cform.widgets.uidreference import UIDReferenceWidgetFactory
 
 
 class IMaterialTypeSchema(model.Schema):
@@ -25,8 +27,22 @@ class IMaterialTypeSchema(model.Schema):
         required=False,
     )
 
+    directives.widget(
+        "material_class",
+        UIDReferenceWidgetFactory,
+        catalog=SETUP_CATALOG,
+        query={
+            "portal_type": "MaterialClass",
+            "is_active": True,
+            "sort_on": "sort_key",
+            "sort_order": "ascending",
+        },
+        limit=5,
+    )
+
     material_class = UIDReferenceField(
         title=u"Material Class",
+        relationship="MaterialTypeMaterialClass",
         allowed_types=("MaterialClass", ),
         multi_valued=False,
         required=False,

--- a/src/bika/cement/content/mixmaterial.py
+++ b/src/bika/cement/content/mixmaterial.py
@@ -3,12 +3,13 @@
 from AccessControl import ClassSecurityInfo
 from bika.cement.interfaces import IMixMaterial
 from bika.lims.interfaces import IDeactivable
+from plone.autoform import directives
 from plone.dexterity.content import Container
 from plone.supermodel import model
 from senaite.core.catalog import SETUP_CATALOG
+from senaite.core.z3cform.widgets.uidreference import UIDReferenceWidgetFactory
 from bika.lims import api
 from zope.interface import implementer
-
 from zope import schema
 from senaite.core.schema import UIDReferenceField
 
@@ -44,11 +45,37 @@ class IMixMaterialSchema(model.Schema):
         required=False,
     )
 
+    directives.widget(
+        "supplier",
+        UIDReferenceWidgetFactory,
+        catalog=SETUP_CATALOG,
+        query={
+            "portal_type": "Supplier",
+            "is_active": True,
+            "sort_on": "sortable_title",
+            "sort_order": "ascending",
+        },
+        limit=5,
+    )
+
     supplier = UIDReferenceField(
         title=u"Supplier",
         allowed_types=("Supplier", ),
         multi_valued=False,
         required=False,
+    )
+
+    directives.widget(
+        "material_type",
+        UIDReferenceWidgetFactory,
+        catalog=SETUP_CATALOG,
+        query={
+            "portal_type": "MaterialType",
+            "is_active": True,
+            "sort_on": "sortable_title",
+            "sort_order": "ascending",
+        },
+        limit=5,
     )
 
     material_type = UIDReferenceField(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1164

## Current behavior before PR

- Sort order on material types listing is descending
- The Supplier lookup on mix material creation is sorted on object creation time.
- The Material Types lookup on material class creation is sorted on object creation time.  
 
## Desired behavior after PR is merged

- Sort order on material types listing is ascending
- The Supplier lookup on mix material creation is sorted by title in ascending order.
- The Material Types lookup on material class creation is sorted by title in ascending order.  

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
