### PR TITLE
Add deactivate workflow for all content types

### DIFF
--- a/src/bika/cement/profiles/default/workflows.xml
+++ b/src/bika/cement/profiles/default/workflows.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+    <property name="title">Workflow definitions for bika.cement</property>
+    <bindings>
+        <type type_id="MaterialClass">
+            <bound-workflow workflow_id="senaite_deactivable_type_workflow"/>
+        </type>
+        <type type_id="MaterialType">
+            <bound-workflow workflow_id="senaite_deactivable_type_workflow"/>
+        </type>
+        <type type_id="MixMaterial">
+            <bound-workflow workflow_id="senaite_deactivable_type_workflow"/>
+        </type>
+        <type type_id="MixType">
+            <bound-workflow workflow_id="senaite_deactivable_type_workflow"/>
+        </type>
+        <type type_id="CuringMethod">
+            <bound-workflow workflow_id="senaite_deactivable_type_workflow"/>
+        </type>
+    </bindings>
+</object>
+


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1165

## Current behavior before PR

All the new content types have no deactivate functionality.

## Desired behavior after PR is merged

All the new content types can now be deactivated.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
