### PR TITLE
Lims 1125 add mix template upload button to batch

### DIFF
--- a/src/bika/cement/browser/listingview/batchfolder.py
+++ b/src/bika/cement/browser/listingview/batchfolder.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2021 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.cement.config import _
+from bika.cement.config import is_installed
+from bika.lims.utils import get_link
+from bika.lims import api
+from senaite.app.listing.interfaces import IListingView
+from senaite.app.listing.interfaces import IListingViewAdapter
+from zope.component import adapts
+from zope.interface import implements
+
+
+class BatchesListingViewAdapter(object):
+    adapts(IListingView)
+    implements(IListingViewAdapter)
+
+    def __init__(self, listing, context):
+        self.listing = listing
+        self.context = context
+
+    def before_render(self):
+        if not is_installed():
+            return
+
+        mix_template_file = [
+            (
+                "MixTemplateFile",
+                {"toggle": False, "sortable": False, "title": _("Mix Template")},
+            )
+        ]
+
+        self.listing.columns.update(mix_template_file)
+        for i in range(len(self.listing.review_states)):
+            self.listing.review_states[i]["columns"].append("MixTemplateFile")
+
+    def folder_item(self, obj, item, index):
+        if not is_installed():
+            return item
+        obj = api.get_object(obj)
+        # using the regular obj.DateExported gives us errors
+        # hence we are using the schema to get the value
+        mix_template_file = obj.MixTemplateFile
+        filesize = mix_template_file.get_size()
+        if filesize > 0:
+            url = item.get("url")
+            filename = mix_template_file.getFilename()
+            download_url = "{}/at_download/MixTemplateFile".format(url)
+            anchor = get_link(download_url, filename)
+            item["MixTemplateFile"] = filename
+            item["replace"]["MixTemplateFile"] = anchor
+        return item

--- a/src/bika/cement/browser/listingview/batchfolder.py
+++ b/src/bika/cement/browser/listingview/batchfolder.py
@@ -43,7 +43,11 @@ class BatchesListingViewAdapter(object):
         mix_template_file = [
             (
                 "MixTemplateFile",
-                {"toggle": False, "sortable": False, "title": _("Mix Template")},
+                {
+                    "toggle": False,
+                    "sortable": False,
+                    "title": _("Mix Template"),
+                },
             )
         ]
 

--- a/src/bika/cement/browser/listingview/configure.zcml
+++ b/src/bika/cement/browser/listingview/configure.zcml
@@ -8,4 +8,11 @@
             provides="senaite.app.listing.interfaces.IListingViewAdapter"
             factory=".samples.SamplesListingViewAdapter"/>
 
+    <!-- batch listing -->
+    <subscriber
+            for="bika.lims.browser.batchfolder.BatchFolderContentsView
+                 zope.interface.Interface"
+            provides="senaite.app.listing.interfaces.IListingViewAdapter"
+            factory=".batchfolder.BatchesListingViewAdapter"/>
+
 </configure>

--- a/src/bika/cement/extenders/batch.py
+++ b/src/bika/cement/extenders/batch.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+from archetypes.schemaextender.interfaces import IBrowserLayerAwareExtender
+from archetypes.schemaextender.interfaces import ISchemaExtender
+from bika.cement.config import _
+from bika.cement.interfaces import IBikaCementLayer
+from bika.cement.extenders.fields import ExtFileField
+from bika.lims.interfaces import IBatch
+from Products.Archetypes.atapi import FileWidget
+from zope.component import adapts
+from zope.interface import implementer
+
+
+mix_template_file = ExtFileField(
+    "MixTemplateFile",
+    widget=FileWidget(
+        label=_("Mix Template"),
+    ),
+)
+
+
+@implementer(ISchemaExtender, IBrowserLayerAwareExtender)
+class BatchSchemaExtender(object):
+    adapts(IBatch)
+    layer = IBikaCementLayer
+
+    fields = [
+        mix_template_file,
+    ]
+
+    def __init__(self, context):
+        self.context = context
+
+    def getOrder(self, schematas):
+        return schematas
+
+    def getFields(self):
+        return self.fields

--- a/src/bika/cement/extenders/configure.zcml
+++ b/src/bika/cement/extenders/configure.zcml
@@ -8,4 +8,8 @@
              provides="archetypes.schemaextender.interfaces.ISchemaExtender"
              factory=".analysisrequest.AnalysisRequestSchemaExtender"/>
 
+    <adapter name="bika.cement.batch"
+             provides="archetypes.schemaextender.interfaces.ISchemaExtender"
+             factory=".batch.BatchSchemaExtender"/>
+
 </configure>

--- a/src/bika/cement/extenders/fields.py
+++ b/src/bika/cement/extenders/fields.py
@@ -17,11 +17,11 @@
 #
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
-
 import six
 from archetypes.schemaextender.interfaces import IExtensionField
 from Products.Archetypes import public
 from bika.lims.browser.fields import UIDReferenceField
+from plone.app.blob.field import FileField
 from zope.interface import implements
 from zope.site.hooks import getSite
 
@@ -79,4 +79,8 @@ class ExtensionField(object):
 
 
 class ExtUIDReferenceField(ExtensionField, UIDReferenceField):
+    "Field extender"
+
+
+class ExtFileField(ExtensionField, FileField):
     "Field extender"

--- a/src/bika/cement/extenders/fields.py
+++ b/src/bika/cement/extenders/fields.py
@@ -17,11 +17,12 @@
 #
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
+
 import six
 from archetypes.schemaextender.interfaces import IExtensionField
-from Products.Archetypes import public
 from bika.lims.browser.fields import UIDReferenceField
 from plone.app.blob.field import FileField
+from Products.Archetypes import public
 from zope.interface import implements
 from zope.site.hooks import getSite
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://bika.atlassian.net/browse/LIMS-1125

## Current behavior before PR

There is no mix template attachment upload button on a batch when bika.cement is installed.

## Desired behavior after PR is merged

- A mix template upload button has been added to the batch create and edit view.
- The uploaded Mix template has been added to the batch listing view and can be downloaded from there.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
